### PR TITLE
- Fixed #156 Integrations now getting set in LV2 and for LV2 Applicat…

### DIFF
--- a/rest/networkProtocols/LoRaOpenSource.js
+++ b/rest/networkProtocols/LoRaOpenSource.js
@@ -3367,7 +3367,7 @@ function normalizeDeviceData (remoteDevice) {
     normalized.deviceKeys = {
       appKey: remoteDevice.deviceKeys.appKey,
       devEUI: remoteDevice.deviceKeys.devEUI,
-      nwkKey: remoteDevice.deviceKeys.nwkKey
+      nwkKey: remoteDevice.deviceKeys.appKey
     }
   }
   /*

--- a/rest/networkProtocols/LoRaOpenSource_2.js
+++ b/rest/networkProtocols/LoRaOpenSource_2.js
@@ -125,10 +125,11 @@ module.exports.test = function (network, loginData) {
           }
         }
         else {
-          appLogger.log('Test Error: ' + error)
+          appLogger.log('Test Error: ', 'error')
           if (response && response.statusCode) {
             appLogger.log(response.statusCode)
           }
+          appLogger.log(error, 'error')
           reject(error)
         }
       })
@@ -337,7 +338,8 @@ function getANetworkServerID (network, connection) {
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Network Server: ' + error)
+          appLogger.log('Error on get Network Server: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -385,7 +387,8 @@ function getNetworkServerById (network, networkServerId, connection, dataAPI) {
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Network Server: ' + error)
+          appLogger.log('Error on get Network Server: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -422,17 +425,18 @@ function getDeviceProfileById (network, dpId, connection, dataAPI) {
       'secureProtocol': 'TLSv1_2_method',
       'rejectUnauthorized': false
     }
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Device Profile: ' + error)
+          appLogger.log('Error on get Device Profile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
           var bodyObj = JSON.parse(response.body)
           appLogger.log(bodyObj)
-          appLogger.log(options)
+          appLogger.log(options, 'warn')
           appLogger.log('Error on get Device Profile: ' +
             bodyObj.error +
             ' (' + response.statusCode + ')')
@@ -464,11 +468,12 @@ function getRemoteDeviceById (network, deviceId, connection) {
       'secureProtocol': 'TLSv1_2_method',
       'rejectUnauthorized': false
     }
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Device: ' + error)
+          appLogger.log('Error on get Device: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -503,11 +508,12 @@ function getRemoteDeviceKey (network, device, connection) {
       'secureProtocol': 'TLSv1_2_method',
       'rejectUnauthorized': false
     }
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Device Keys: ' + error)
+          appLogger.log('Error on get Device Keys: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else if (response.statusCode === 404) {
@@ -546,11 +552,12 @@ function getRemoteDeviceActivation (network, device, connection) {
       'secureProtocol': 'TLSv1_2_method',
       'rejectUnauthorized': false
     }
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Device Keys: ' + error)
+          appLogger.log('Error on get Device Keys: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else if (response.statusCode === 404) {
@@ -595,7 +602,8 @@ function getServiceProfileById (network, serviceProfileId, connection, dataAPI) 
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Service Profile: ' + error)
+          appLogger.log('Error on get Service Profile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -633,11 +641,12 @@ function getApplicationById (network, applicationId, connection) {
       'rejectUnauthorized': false
     }
 
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get Application: ' + error)
+          appLogger.log('Error on get Application: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -679,7 +688,8 @@ function getServiceProfileForOrg (network, orgId, companyId, connection, dataAPI
     request(spOptions, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error getting Service Profile: ' + error)
+          appLogger.log('Error getting Service Profile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -820,7 +830,8 @@ module.exports.connect = function (network, loginData) {
     options.agentOptions = {'secureProtocol': 'TLSv1_2_method', 'rejectUnauthorized': false}
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error on signin: ' + error)
+        appLogger.log('Error on signin: ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else if (response.statusCode >= 400 || response.statusCode === 301) {
@@ -909,7 +920,8 @@ module.exports.addCompany = function (sessionData, network, companyId, dataAPI) 
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on create company ' + company.name + ': ' + error)
+          appLogger.log('Error on create company ' + company.name + ': ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -968,7 +980,8 @@ module.exports.addCompany = function (sessionData, network, companyId, dataAPI) 
               if (error) {
                 appLogger.log('Error creating ' + company.name +
                   "'s admin user " + userOptions.json.username +
-                  ': ' + error)
+                  ': ', 'error')
+                appLogger.log(error, 'error')
                 reject(error)
                 return
               }
@@ -1026,7 +1039,8 @@ module.exports.addCompany = function (sessionData, network, companyId, dataAPI) 
             request(spOptions, async function (error, response, body) {
               if (error || response.statusCode >= 400) {
                 if (error) {
-                  appLogger.log('Error creating default Service Profile: ' + error)
+                  appLogger.log('Error creating default Service Profile: ', 'error')
+                  appLogger.log(error, 'error')
                   reject(error)
                 }
                 else {
@@ -1109,7 +1123,8 @@ module.exports.getCompany = function (sessionData, network, companyId, dataAPI) 
 
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error getting company ' + company.name + ': ' + error)
+        appLogger.log('Error getting company ' + company.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1170,7 +1185,8 @@ module.exports.updateCompany = function (sessionData, network, companyId, dataAP
     request(options, function (error, response, body) {
       if (error) {
         appLogger.log('Error updating company ' + company.name +
-          ': ' + error)
+          ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1229,7 +1245,8 @@ module.exports.deleteCompany = function (sessionData, network, companyId, dataAP
     }
     request(userOptions, function (error, response, body) {
       if (error) {
-        appLogger.log("Error on delete company's admin user: " + error)
+        appLogger.log("Error on delete company's admin user: ", 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1248,7 +1265,8 @@ module.exports.deleteCompany = function (sessionData, network, companyId, dataAP
 
         request(options, async function (error, response, body) {
           if (error) {
-            appLogger.log('Error on delete company: ' + error)
+            appLogger.log('Error on delete company: ', 'error')
+            appLogger.log(error, 'error')
             reject(error)
           }
           else {
@@ -1567,10 +1585,11 @@ module.exports.setupOrganization = function (sessionData, network, modelAPI, dat
       'rejectUnauthorized': false
     }
 
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error getting operator ' + company.name + ' from network ' + network.name + ': ' + error)
+        appLogger.log('Error getting operator ' + company.name + ' from network ' + network.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1667,10 +1686,11 @@ module.exports.pullDeviceProfiles = function (sessionData, network, modelAPI, co
       'rejectUnauthorized': false
     }
 
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error pulling device profiles from network ' + network.name + ': ' + error)
+        appLogger.log('Error pulling device profiles from network ' + network.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1741,17 +1761,20 @@ module.exports.addRemoteDeviceProfile = function (sessionData, limitedRemoteDevi
                 })
                 .catch((error) => {
                   appLogger.log(error)
+                  appLogger.log(error, 'error')
                   reject(error)
                 })
             }
           })
           .catch((error) => {
             appLogger.log(error)
+            appLogger.log(error, 'error')
             reject(error)
           })
       })
       .catch((error) => {
         appLogger.log(error)
+        appLogger.log(error, 'error')
         reject(error)
       })
   })
@@ -1780,10 +1803,11 @@ module.exports.pullApplications = function (sessionData, network, modelAPI, data
       'rejectUnauthorized': false
     }
 
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error pulling applications from network ' + network.name + ': ' + error)
+        appLogger.log('Error pulling applications from network ' + network.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1871,7 +1895,8 @@ module.exports.pullDevices = function (sessionData, network, remoteApplicationId
     appLogger.log(options, 'error')
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error pulling devices from network ' + network.name + ': ' + error)
+        appLogger.log('Error pulling devices from network ' + network.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -1964,15 +1989,17 @@ module.exports.pullIntegrations = function (sessionData, network, remoteApplicat
       'secureProtocol': 'TLSv1_2_method',
       'rejectUnauthorized': false
     }
-    appLogger.log(options)
+    appLogger.log(options, 'error')
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error pulling integrations from network ' + network.name + ': ' + error)
+        appLogger.log('Error pulling integrations from network ' + network.name + ': ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
         let integration = JSON.parse(body)
-        appLogger.log(integration)
+        integration = integration.integration
+        appLogger.log(integration, 'warn')
         var deliveryURL = 'api/ingest/' + localApplicationId + '/' + network.id
         var reportingUrl = nconf.get('base_url') + deliveryURL
 
@@ -1982,12 +2009,12 @@ module.exports.pullIntegrations = function (sessionData, network, remoteApplicat
         else {
           modelAPI.applications.retrieveApplication(localApplicationId)
             .then(appToUpdate => {
-              appToUpdate.baseUrl = integration.dataUpURL
-              appLogger.log(appToUpdate)
+              appToUpdate.baseUrl = integration.uplinkDataURL
+              appLogger.log(appToUpdate, 'warn')
               delete appToUpdate.networks
               modelAPI.applications.updateApplication(appToUpdate)
                 .then(result => {
-                  appLogger.log(result)
+                  appLogger.log(result, 'warn')
                   let options2 = {}
                   options2.method = 'PUT'
                   options2.url = network.baseUrl + '/applications/' + remoteApplicationId + '/integrations/http'
@@ -2001,19 +2028,23 @@ module.exports.pullIntegrations = function (sessionData, network, remoteApplicat
                   }
 
                   options2.json = {
-                    ackNotificationURL: reportingUrl,
-                    dataUpURL: reportingUrl,
-                    errorNotificationURL: reportingUrl,
-                    id: integration.id,
-                    joinNotificationURL: reportingUrl
+                    integration: {
+                      ackNotificationURL: reportingUrl,
+                      uplinkDataURL: reportingUrl,
+                      errorNotificationURL: reportingUrl,
+                      id: integration.id,
+                      joinNotificationURL: reportingUrl
+                    }
                   }
                   appLogger.log(options2)
                   request(options2, function (error, response, body) {
                     if (error) {
-                      appLogger.log('Error updating integrations from network ' + network.name + ': ' + error)
+                      appLogger.log('Error updating integrations from network ' + network.name + ': ', 'error')
+                      appLogger.log(error, 'error')
                       reject(error)
                     }
                     else {
+                      appLogger.log('Success Setting Integrations', 'warn')
                       resolve()
                     }
                   })
@@ -2093,7 +2124,8 @@ module.exports.addApplication = function (sessionData, network, applicationId, d
       request(options, async function (error, response, body) {
         if (error || response.statusCode >= 400) {
           if (error) {
-            appLogger.log('Error on create application: ' + error)
+            appLogger.log('Error on create application: ', 'error')
+            appLogger.log(error, 'error')
             reject(error)
           }
           else {
@@ -2157,7 +2189,8 @@ module.exports.getApplication = function (sessionData, network, applicationId, d
 
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error on get application: ' + error)
+        appLogger.log('Error on get application: ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -2257,11 +2290,12 @@ module.exports.updateApplication = function (sessionData, network, applicationId
     }
     appLogger.log(application)
     appLogger.log(applicationData)
-    appLogger.log(options)
+    appLogger.log(options, 'warn')
 
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error on update application: ' + error)
+        appLogger.log('Error on update application: ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -2308,7 +2342,8 @@ module.exports.deleteApplication = function (sessionData, network, applicationId
 
     request(options, async function (error, response, body) {
       if (error) {
-        appLogger.log('Error on delete application: ' + error)
+        appLogger.log('Error on delete application: ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -2373,7 +2408,8 @@ module.exports.startApplication = function (sessionData, network, applicationId,
 
       request(options, function (error, response, body) {
         if (error) {
-          appLogger.log('Error on add application data reporting: ' + error)
+          appLogger.log('Error on add application data reporting: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -2440,7 +2476,8 @@ module.exports.stopApplication = function (sessionData, network, applicationId, 
     }
     request(options, function (error, response, body) {
       if (error) {
-        appLogger.log('Error on delete application notification: ' + error)
+        appLogger.log('Error on delete application notification: ', 'error')
+        appLogger.log(error, 'error')
         reject(error)
       }
       else {
@@ -2566,11 +2603,12 @@ module.exports.addDeviceProfile = function (sessionData, network, deviceProfileI
         'rejectUnauthorized': false
       }
 
-      appLogger.log(options)
+      appLogger.log(options, 'warn')
       request(options, async function (error, response, body) {
         if (error || response.statusCode >= 400) {
           if (error) {
-            appLogger.log('Error on create deviceProfile ' + deviceProfile.name + ':  ' + error)
+            appLogger.log('Error on create deviceProfile ' + deviceProfile.name + ':  ', 'error')
+            appLogger.log(error, 'error')
             reject(error)
           }
           else {
@@ -2638,7 +2676,8 @@ module.exports.getDeviceProfile = function (sessionData, network, deviceProfileI
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get deviceProfile: ' + error)
+          appLogger.log('Error on get deviceProfile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -2775,7 +2814,8 @@ module.exports.updateDeviceProfile = function (sessionData, network, deviceProfi
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on put deviceProfile: ' + error)
+          appLogger.log('Error on put deviceProfile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -2839,7 +2879,8 @@ module.exports.deleteDeviceProfile = function (sessionData, network, deviceProfi
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on delete deviceProfile: ' + error)
+          appLogger.log('Error on delete deviceProfile: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -2887,7 +2928,7 @@ module.exports.addDevice = function (sessionData, network, deviceId, dataAPI) {
       dntl = await dataAPI.getDeviceNetworkType(deviceId, network.networkTypeId)
       deviceProfile = await dataAPI.getDeviceProfileById(dntl.deviceProfileId)
       if (!dntl.networkSettings || !dntl.networkSettings.devEUI) {
-        appLogger.log('deviceNetworkTypeLink MUST have networkSettings which MUST have devEUI')
+        appLogger.log('deviceNetworkTypeLink MUST have networkSettings which MUST have devEUI', 'error')
         reject(400)
         return
       }
@@ -2900,7 +2941,7 @@ module.exports.addDevice = function (sessionData, network, deviceId, dataAPI) {
         network.networkProtocolId,
         makeDeviceProfileDataKey(dntl.deviceProfileId, 'dpNwkId'))
 
-      let loraV2Device = deNormalizeDeviceData(dntl.networkSettings, appNwkId, dpNwkId)
+      let loraV2Device = deNormalizeDeviceData(dntl.networkSettings, deviceProfile.networkSettings, appNwkId, dpNwkId)
       // Set up the request options.
       var options = {}
       options.method = 'POST'
@@ -2917,60 +2958,57 @@ module.exports.addDevice = function (sessionData, network, deviceId, dataAPI) {
         'rejectUnauthorized': false
       }
 
-      appLogger.log(options, 'info')
+      appLogger.log(options, 'warn')
       request(options, function (error, response, body) {
         if (error || response.statusCode >= 400) {
           if (error) {
-            appLogger.log('Error on create device: ' + error)
+            appLogger.log('Error on create device: ', 'error')
+            appLogger.lop(error, 'error')
+            appLogger.log(error, 'error')
             reject(error)
           }
           else {
-            appLogger.log('Error on create device (' + response.statusCode + '): ' + body.error)
+            appLogger.log('Error on create device (' + response.statusCode + '): ', 'error')
+            appLogger.log(body, 'error')
             reject(response.statusCode)
           }
         }
         else {
-        // LoRa Open Source uses the DevEUI as the node id.
           dataAPI.putProtocolDataForKey(network.id,
             network.networkProtocolId,
             makeDeviceDataKey(device.id, 'devNwkId'),
             loraV2Device.device.devEUI)
 
-          appLogger.log(loraV2Device, 'info')
+          appLogger.log(loraV2Device, 'warn')
 
-          // Devices have to do a second call to set up either the
-          // Application Key (OTAA) or the Keys for ABP.
           if (deviceProfile.networkSettings.supportsJoin && loraV2Device.deviceKeys) {
-            // This is the OTAA path.
             options.url = network.baseUrl + '/devices/' +
               loraV2Device.device.devEUI + '/keys'
             options.json = {
-              devEUI: loraV2Device.devEUI,
               deviceKeys: loraV2Device.deviceKeys
             }
           }
           else if (loraV2Device.deviceActivation) {
-            // This is the ABP path.
-            options.url = network.baseUrl + '/devices/' +
-              loraV2Device.device.devEUI + '/activate'
+            options.url = network.baseUrl + '/devices/' + loraV2Device.device.devEUI + '/activate'
             options.json = {
               deviceActivation: loraV2Device.deviceActivation
             }
-            appLogger.log('options.json = ' + JSON.stringify(options))
           }
           else {
-            appLogger.log('Remote Device ' + loraV2Device.name + ' does not have authentication parameters')
+            appLogger.log('Remote Device ' + loraV2Device.name + ' does not have authentication parameters', 'error')
             resolve(dntl.networkSettings.devEUI)
             return
           }
+          appLogger.log(options, 'warn')
           request(options, function (error, response, body) {
             if (error || response.statusCode >= 400) {
               if (error) {
-                appLogger.log('Error on create device keys/activation: ' + error)
+                appLogger.log('Error on create device keys/activation: ', 'error')
+                appLogger.log(error)
               }
               else {
-                appLogger.log('Error on create device keys/activation (' + response.statusCode + '): ')
-                appLogger.log(body, 'info')
+                appLogger.log('Error on create device keys/activation (' + response.statusCode + '): ', 'error')
+                appLogger.log(body, 'error')
               }
               resolve(dntl.networkSettings.devEUI)
             }
@@ -2982,7 +3020,8 @@ module.exports.addDevice = function (sessionData, network, deviceId, dataAPI) {
       })
     }
     catch (err) {
-      appLogger.log('Error getting data for remote network: ' + err)
+      appLogger.log('Error getting data for remote network: ', 'error')
+      appLogger.log(err, 'error')
       reject(err)
     }
   })
@@ -3030,7 +3069,8 @@ module.exports.getDevice = function (sessionData, network, deviceId, dataAPI) {
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on get device: ' + error)
+          appLogger.log('Error on get device: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -3110,8 +3150,9 @@ module.exports.updateDevice = function (sessionData, network, deviceId, dataAPI)
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on update device: ' + error)
-          appLogger.log('Error on update device: ' + error)
+          appLogger.log('Error on update device: ', 'error')
+          appLogger.log('Error on update device: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -3132,7 +3173,7 @@ module.exports.updateDevice = function (sessionData, network, deviceId, dataAPI)
         request(options, function (error, response, body) {
           if (error || response.statusCode >= 400) {
             if (error) {
-              appLogger.log('Error on update device keys: ' + error)
+              appLogger.log('Error on update device keys: ', 'error')
             }
             else {
               appLogger.log('Error on update device keys (' + response.statusCode + '): ' + body.error)
@@ -3194,7 +3235,8 @@ module.exports.deleteDevice = function (sessionData, network, deviceId, dataAPI)
     request(options, async function (error, response, body) {
       if (error || response.statusCode >= 400) {
         if (error) {
-          appLogger.log('Error on delete device: ' + error)
+          appLogger.log('Error on delete device: ', 'error')
+          appLogger.log(error, 'error')
           reject(error)
         }
         else {
@@ -3219,7 +3261,7 @@ module.exports.deleteDevice = function (sessionData, network, deviceId, dataAPI)
         request(options, function (error, response, body) {
           if (error || response.statusCode >= 400) {
             if (error) {
-              appLogger.log('Error on delete device keys: ' + error)
+              appLogger.log('Error on delete device keys: ', 'error')
             }
             else {
               appLogger.log('Error on delete device keys (' + response.statusCode + '): ' + body.error)
@@ -3478,7 +3520,7 @@ function normalizeDeviceData (remoteDevice) {
  * @param remoteDevice
  * @returns {{device: {applicationID: (*|string), description: *, devEUI: *, deviceProfileID: *, name: *, skipFCntCheck: (*|boolean)}, deviceStatusBattery: number, deviceStatusMargin: number, lastSeenAt: (string|null)}}
  */
-function deNormalizeDeviceData (remoteDevice, appId, dpId) {
+function deNormalizeDeviceData (remoteDevice, deviceProfile, appId, dpId) {
   let loraV2DeviceData = {
     device: {
       applicationID: appId,
@@ -3490,10 +3532,19 @@ function deNormalizeDeviceData (remoteDevice, appId, dpId) {
     }
   }
   if (remoteDevice.deviceKeys) {
-    loraV2DeviceData.deviceKeys = {
-      appKey: remoteDevice.deviceKeys.appKey,
-      nwkKey: remoteDevice.deviceKeys.nwkKey,
-      devEUI: remoteDevice.deviceKeys.devEUI
+    if (deviceProfile.macVersion === '1.1.0') {
+      loraV2DeviceData.deviceKeys = {
+        appKey: remoteDevice.deviceKeys.appKey,
+        nwkKey: remoteDevice.deviceKeys.nwkKey,
+        devEUI: remoteDevice.deviceKeys.devEUI
+      }
+    }
+    else {
+      loraV2DeviceData.deviceKeys = {
+        nwkKey: remoteDevice.deviceKeys.nwkKey,
+        devEUI: remoteDevice.deviceKeys.devEUI,
+        appKey: ''
+      }
     }
   }
   if (remoteDevice.deviceActivation) {
@@ -3508,7 +3559,7 @@ function deNormalizeDeviceData (remoteDevice, appId, dpId) {
       fNwkSIntKey: remoteDevice.deviceActivation.fNwkSIntKey
     }
   }
-  appLogger.log(remoteDevice, 'info')
-  appLogger.log(loraV2DeviceData, 'info')
+  appLogger.log(remoteDevice, 'warn')
+  appLogger.log(loraV2DeviceData, 'warn')
   return loraV2DeviceData
 }

--- a/rest/networkProtocols/TheThingsNetwork.js
+++ b/rest/networkProtocols/TheThingsNetwork.js
@@ -99,7 +99,7 @@ module.exports = {
  * @returns {Promise<?>} - Empty promise means register worked
  */
 module.exports.register = function (networkProtocols) {
-  appLogger.log('TTN:register', 'warn')
+  appLogger.log('TTN:register', 'info')
   return new Promise(async function (resolve, reject) {
     let me = {
       name: 'The Things Network',
@@ -463,7 +463,7 @@ module.exports.pullNetwork = function (session, network, dataAPI, modelAPI) {
 
     Promise.all(promiseList)
       .then(pulledResources => {
-        appLogger.log(pulledResources, 'warn')
+        appLogger.log(pulledResources, 'info')
         let devicePromistList = []
         for (let index in pulledResources[0]) {
           devicePromistList.push(me.pullDevices(session, network, pulledResources[0][index].remoteApplication, pulledResources[0][index].localApplication, {}, modelAPI, dataAPI))
@@ -472,7 +472,7 @@ module.exports.pullNetwork = function (session, network, dataAPI, modelAPI) {
         Promise.all(devicePromistList)
           .then((devices) => {
             appLogger.log(devices, 'info')
-            appLogger.log('Success Pulling Network ' + network.name, 'warn')
+            appLogger.log('Success Pulling Network ' + network.name, 'info')
             resolve()
           })
           .catch(err => {
@@ -545,8 +545,8 @@ function addRemoteApplication (session, limitedRemoteApplication, network, model
       let existingApplication = await modelAPI.applications.retrieveApplications({search: normalizedApplication.name})
       if (existingApplication.totalCount > 0) {
         existingApplication = existingApplication.records[0]
-        appLogger.log(existingApplication.name + ' already exists', 'warn')
-        appLogger.log(normalizedApplication, 'warn')
+        appLogger.log(existingApplication.name + ' already exists', 'info')
+        appLogger.log(normalizedApplication, 'info')
       }
       else {
         existingApplication = await modelAPI.applications.createApplication(normalizedApplication.name, normalizedApplication.description, 2, network.networkTypeId, 'http://set.me.to.your.real.url:8888')
@@ -555,11 +555,11 @@ function addRemoteApplication (session, limitedRemoteApplication, network, model
 
       let existingApplicationNTL = await modelAPI.applicationNetworkTypeLinks.retrieveApplicationNetworkTypeLinks({applicationId: existingApplication.id})
       if (existingApplicationNTL.totalCount > 0) {
-        appLogger.log(existingApplication.name + ' link already exists', 'warn')
+        appLogger.log(existingApplication.name + ' link already exists', 'info')
       }
       else {
         existingApplicationNTL = await modelAPI.applicationNetworkTypeLinks.createRemoteApplicationNetworkTypeLink(existingApplication.id, network.networkTypeId, normalizedApplication, existingApplication.companyId)
-        appLogger.log(existingApplicationNTL, 'warn')
+        appLogger.log(existingApplicationNTL, 'info')
         let temp = await dataAPI.putProtocolDataForKey(network.id,
           network.networkProtocolId,
           makeApplicationDataKey(existingApplication.id, 'appNwkId'),
@@ -636,7 +636,7 @@ module.exports.pullDevices = function (session, network, remoteApplicationId, lo
       'rejectUnauthorized': false
     }
 
-    appLogger.log(options, 'warn')
+    appLogger.log(options, 'info')
     request(options, function (error, response, body) {
       if (error) {
         appLogger.log('Error pulling devices from network ' + network.name, 'error')
@@ -644,7 +644,7 @@ module.exports.pullDevices = function (session, network, remoteApplicationId, lo
         reject(error)
       }
       else {
-        appLogger.log(body, 'warn')
+        appLogger.log(body, 'info')
         let devices = {}
         if (typeof body === 'object') {
           devices = body.devices
@@ -766,7 +766,7 @@ module.exports.pushNetwork = function (session, network, dataAPI, modelAPI) {
         devicePromiseList.push(me.pushDevices(session, network, dataAPI, modelAPI))
         Promise.all(devicePromiseList)
           .then(pushedResource => {
-            appLogger.log('Success Pushing Network ' + network.name, 'warn')
+            appLogger.log('Success Pushing Network ' + network.name, 'info')
             appLogger.log(pushedResource, 'info')
             resolve()
           })
@@ -786,15 +786,15 @@ module.exports.pushApplications = function (session, network, dataAPI, modelAPI)
   let me = this
   return new Promise(async function (resolve, reject) {
     let existingApplications = await modelAPI.applications.retrieveApplications()
-    appLogger.log(existingApplications, 'warn')
+    appLogger.log(existingApplications, 'info')
     let promiseList = []
     for (let index = 0; index < existingApplications.records.length; index++) {
       promiseList.push(me.pushApplication(session, network, existingApplications.records[index], dataAPI, modelAPI))
     }
     Promise.all(promiseList)
       .then(pushedResources => {
-        appLogger.log('Success Pushing Applications', 'warn')
-        appLogger.log(pushedResources, 'warn')
+        appLogger.log('Success Pushing Applications', 'info')
+        appLogger.log(pushedResources, 'info')
         resolve(pushedResources)
       })
       .catch(err => {
@@ -815,7 +815,7 @@ module.exports.pushApplication = function (session, network, application, dataAP
       makeApplicationDataKey(application.id, 'appNwkId'))
       .then(appNetworkId => {
         if (appNetworkId) {
-          appLogger.log('Ignoring Application  ' + application.id + ' already on network ' + network.name + ' as ' + appNetworkId, 'warn')
+          appLogger.log('Ignoring Application  ' + application.id + ' already on network ' + network.name + ' as ' + appNetworkId, 'info')
           resolve({localApplication: application.id, remoteApplication: appNetworkId})
         }
         else {
@@ -823,10 +823,10 @@ module.exports.pushApplication = function (session, network, application, dataAP
         }
       })
       .catch(() => {
-        appLogger.log('Pushing Application ' + application.name, 'warn')
+        appLogger.log('Pushing Application ' + application.name, 'info')
         me.addApplication(session, network, application.id, dataAPI, modelAPI)
           .then((appNetworkId) => {
-            appLogger.log('Added application ' + application.id + ' to network ' + network.name, 'warn')
+            appLogger.log('Added application ' + application.id + ' to network ' + network.name, 'info')
             resolve({localApplication: application.id, remoteApplication: appNetworkId})
           })
           .catch(err => {
@@ -865,21 +865,21 @@ module.exports.pushDevice = function (sessionData, network, device, dataAPI) {
       network.networkProtocolId,
       makeDeviceDataKey(device.id, 'devNwkId'))
       .then(devNetworkId => {
-        appLogger.log('Ignoring Device  ' + device.id + ' already on network ' + network.name, 'warn')
+        appLogger.log('Ignoring Device  ' + device.id + ' already on network ' + network.name, 'info')
         if (devNetworkId) {
           resolve({localDevice: device.id, remoteDevice: devNetworkId})
         }
         else {
-          appLogger.log(devNetworkId + ' found for network ' + network.name + ' for device ' + device.id, 'warn')
+          appLogger.log(devNetworkId + ' found for network ' + network.name + ' for device ' + device.id, 'info')
           reject(new Error('Something bad happened with the Protocol Table'))
         }
       })
       .catch(() => {
-        appLogger.log('Adding Device  ' + device.id + ' to network ' + network.name, 'warn')
+        appLogger.log('Adding Device  ' + device.id + ' to network ' + network.name, 'info')
 
         me.addDevice(sessionData, network, device.id, dataAPI)
           .then((devNetworkId) => {
-            appLogger.log('Added Device  ' + device.id + ' to network ' + network.name, 'warn')
+            appLogger.log('Added Device  ' + device.id + ' to network ' + network.name, 'info')
             resolve({localDevice: device.id, remoteDevice: devNetworkId})
           })
           .catch(err => {
@@ -946,7 +946,7 @@ module.exports.addApplication = function (session, network, applicationId, dataA
       }
       else {
         try {
-          appLogger.log(body, 'warn')
+          appLogger.log(body, 'info')
           let response = {}
           if (typeof body === 'object') {
             response = body
@@ -1459,7 +1459,7 @@ function postSingleDevice (session, network, device, deviceProfile, application,
     delete ttnDevice.attributes
     let options = getOptions('POST', 'http://us-west.thethings.network:8084', 'handler', 'applications/' + ttnDevice.app_id + '/devices', session.connection.access_token)
     options.json = ttnDevice
-    appLogger.log(options, 'warn')
+    appLogger.log(options, 'info')
 
     request(options, function (error, response, body) {
       if (error || response.statusCode >= 400) {
@@ -1513,7 +1513,7 @@ module.exports.addDevice = function (session, network, deviceId, dataAPI) {
                     appLogger.log('Moment of Truth', 'error')
                     postSingleDevice(session, network, dntl, deviceProfile, applicationData, remoteApplicationId, dataAPI)
                       .then(result => {
-                        appLogger.log('Success Adding Device ' + ' to ' + network.name, 'warn')
+                        appLogger.log('Success Adding Device ' + ' to ' + network.name, 'info')
                         resolve(result)
                       }).catch(err => {
                       appLogger.log(err, 'error')
@@ -2207,11 +2207,12 @@ function normalizeDeviceData (remoteDevice, deviceProfileId) {
     deviceStatusMargin: '',
     lastSeenAt: remoteDevice.lorawan_device.last_seen
   }
+  //TTN only supports 1.0.x currently, so  nwkKey == appKey for conversion
   if (remoteDevice.lorawan_device.activation_constraints === 'otaa' || (remoteDevice.lorawan_device.app_key !== '')) {
     normalized.deviceKeys = {
       appKey: remoteDevice.lorawan_device.app_key,
       devEUI: remoteDevice.lorawan_device.dev_eui,
-      nwkKey: remoteDevice.lorawan_device.nwk_key
+      nwkKey: remoteDevice.lorawan_device.app_key
     }
   }
   else {
@@ -2223,7 +2224,8 @@ function normalizeDeviceData (remoteDevice, deviceProfileId) {
       fCntUp: remoteDevice.lorawan_device.f_cnt_up,
       nFCntDown: remoteDevice.lorawan_device.f_cnt_down,
       nwkSEncKey: remoteDevice.lorawan_device.nwk_s_key,
-      sNwkSIntKey: remoteDevice.lorawan_device.sNwkSIntKey
+      sNwkSIntKey: remoteDevice.lorawan_device.nwk_s_key,
+      fNwkSIntKey: remoteDevice.lorawan_device.nwk_s_key
     }
   }
   return normalized


### PR DESCRIPTION
…ions

- Fixed #148, where keys were not getting set in LV2.  The appKey has to be changed to the nwkKey when going from 1.0.x to 1.1 servers.

#### What does this PR do?
Fixes bug where integrations did now get set up in LoraOSV2 when pulling applications
Fixes bug where NwkKey wasn't being set in LoraOSV2 when pushing applications from other networks. 
#### Do you have any concerns with this PR?
No
#### How can the reviewer verify this PR?
Run the demo and verify the LoraV2 server has integrations set to `<lpwanserver>/api/ingest/<appId>/<networkId>`
and LPWan is set to 
`http://localhost:9999`

Also the Keys for the TTN devices should be visible in the LoraV2 Server

#### Any background context you want to provide?
No
#### Screenshots or logs (if appropriate)
![image](https://user-images.githubusercontent.com/4982278/46262247-41b7d180-c4c4-11e8-99cb-a92673dff143.png)

![image](https://user-images.githubusercontent.com/4982278/46262268-6e6be900-c4c4-11e8-9462-8fa5785b11ca.png)

![image](https://user-images.githubusercontent.com/4982278/46262279-a2dfa500-c4c4-11e8-8060-b0fe5584b34a.png)

![image](https://user-images.githubusercontent.com/4982278/46262282-b428b180-c4c4-11e8-9982-89cf091cb76d.png)

#### Questions:
- Have you connected this PR to the issue it resolves?
Yes #148 #156 
- Does the documentation need an update?
No
- Does this add new dependencies?
No
- Have you added unit or functional tests for this PR?
Yes