### PR TITLE
Remove env vars from dockerfile.

### DIFF
--- a/config/defaults.hjson
+++ b/config/defaults.hjson
@@ -41,8 +41,8 @@
 
     // Set up SSL support.  Note that both ssl_key_file and ssl_cert_file
     // must be defined to enable https connections.
-    ssl_key_file:
-    ssl_cert_file:
+    // ssl_key_file:
+    // ssl_cert_file:
 
     // The base URL to use for links back to this site for emails sent
     // to verify user email addresses or pointers back to us for data delivery.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,23 +13,6 @@ RUN npm install
 COPY . .
 
 # see config.hjson for a description of env variables
-ENV log_format_morgan=
-ENV logging_enabled=
-ENV logging_headers=
-ENV jwt_algo=
-ENV jwt_secret=
-ENV jwt_ttl=
-ENV jwt_issuer=
-ENV bind_address=
-ENV port=
-ENV ssl_key_file=
-ENV ssl_cert_file=
-ENV base_url=
-ENV impl_directory=
-ENV db_schema=
-ENV db_create=
-ENV db_file=
-ENV cors_whitelist=
 
 EXPOSE 3200
 


### PR DESCRIPTION
#### What does this PR do?
- Remove env variables from Dockerfile.  Listing the env variables in Dockerfile overwrites the values in defaults.hjson with empty strings.

#### Do you have any concerns with this PR? No

#### How can the reviewer verify this PR?
Run `docker-compose -f docker/docker-compose loraserver -f docker/docker-compose.rest.yml up` and confirm there are not errors.

#### Any background context you want to provide?
I didn't know that declaring ENV variables in Dockerfile sets them to empty strings.

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? #214 
- Does the documentation need an update? No
- Does this add new dependencies? No
- Have you added unit or functional tests for this PR? No
