### PR TITLE
DB caching

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/src/app
 COPY bin/rest bin/rest
 COPY config config
 COPY prisma/generated prisma/generated
+COPY lib/prisma-cache lib/prisma-cache
 COPY restApp.js ./restApp.js
 COPY server.js ./server.js
 COPY public public

--- a/docker/test/unit/Dockerfile
+++ b/docker/test/unit/Dockerfile
@@ -14,4 +14,4 @@ RUN npm install
 # copy all project
 COPY . .
 
-CMD ["nyc", "--reporter=lcovonly", "mocha", "test2.0/unit", "--recursive"]
+CMD ["nyc", "--reporter=lcovonly", "mocha", "test2.0/unit", "--recursive", "--file", "test2.0/unit/setup.js"]

--- a/lib/prisma-cache/src/cache-first-strategy.js
+++ b/lib/prisma-cache/src/cache-first-strategy.js
@@ -1,0 +1,85 @@
+const ObjectHash = require('object-hash')
+const DbModel = require('./db-model')
+const { mkError } = require('./utils')
+
+module.exports = class CacheFirstStrategy extends DbModel {
+  constructor (opts) {
+    super(opts)
+    this.redis = opts.redis
+  }
+
+  key (...args) {
+    return `${this.lowerName}:${args.join(':')}`
+  }
+
+  async cacheRecord (record, args) {
+    try {
+      let hash = ObjectHash.sha1(args)
+      await this.redis.saddAsync(this.key('loadIndex', record.id), hash)
+      await this.redis.setAsync(this.key('load', hash), JSON.stringify(record))
+    }
+    catch (err) {
+      this.log(`Failed to cache ${this.name} record: ${err}`)
+      this.log(JSON.stringify({ record, args }))
+    }
+  }
+
+  async removeFromCache (uniqueKeyObj) {
+    let scanAsync = async (id, start) => {
+      const result = await this.redis.sscanAsync(this.key('loadIndex', id), start)
+      return [ parseInt(result[0], 10), ...result.slice(1) ]
+    }
+    try {
+      const { id } = await this.resolveId(uniqueKeyObj)
+      let scan = await scanAsync(id, 0)
+      let hashes = scan[1]
+      while (scan[0]) {
+        scan = await scanAsync(id, scan[0])
+        hashes = [ ...hashes, ...scan[1] ]
+      }
+      let keys = hashes.map(hash => this.key('load', hash))
+      await Promise.all([
+        this.redis.del(this.key('loadIndex', id)),
+        ...keys.map(x => this.redis.del(x))
+      ])
+    }
+    catch (err) {
+      this.log(`Unable to remove ${this.lowerName} cache for: ${JSON.stringify(uniqueKeyObj)}`)
+      throw mkError(500, err)
+    }
+  }
+
+  async resolveId (uniqueKeyObj) {
+    if (uniqueKeyObj.id) return uniqueKeyObj
+    return super.load(uniqueKeyObj)
+  }
+
+  async load (...args) {
+    const hash = ObjectHash.sha1(args)
+    let record = await this.redis.getAsync(this.key('load', hash))
+    if (record) return JSON.parse(record)
+    record = await super.load(...args)
+    await this.cacheRecord(record, args)
+    return record
+  }
+
+  async update (uniqueKeyObj, data, opts = {}) {
+    await this.removeFromCache(uniqueKeyObj)
+    return super.update(uniqueKeyObj, data, opts)
+  }
+
+  async remove (uniqueKeyObj) {
+    await this.removeFromCache(uniqueKeyObj)
+    return super.remove(uniqueKeyObj)
+  }
+
+  async clearModelFromCache () {
+    let scan = await this.redis.scanAsync(0)
+    let regex = new RegExp(`^${this.lowerName}`)
+    while (parseInt(scan[0], 10)) {
+      let keys = scan[1].filter(x => regex.test(x))
+      await Promise.all(keys.map(x => this.redis.del(x)))
+      scan = await this.redis.scanAsync(scan[0])
+    }
+  }
+}

--- a/lib/prisma-cache/src/db-model.js
+++ b/lib/prisma-cache/src/db-model.js
@@ -1,0 +1,61 @@
+const {
+  onFail,
+  lowerFirst,
+  upperFirst,
+  formatRelationshipsIn,
+  formatInputData,
+  mkError } = require('./utils')
+
+module.exports = class DbModel {
+  constructor ({ name, pluralName, fragments, defaultFragmentKey, prisma, log }) {
+    this.lowerName = lowerFirst(name)
+    this.upperName = upperFirst(name)
+    this.lowerPluralName = lowerFirst(pluralName)
+    this.upperPluralName = upperFirst(pluralName)
+    this.fragments = fragments
+    this.defaultFragmentKey = defaultFragmentKey
+    this.prisma = prisma
+    this.log = log || console.log.bind(console)
+  }
+
+  async load (uniqueKeyObj, opts = {}) {
+    let { prisma, lowerName, fragments } = this
+    let fragment = opts.fragment || this.defaultFragmentKey
+    const rec = await onFail(400, () => prisma[lowerName](uniqueKeyObj).$fragment(fragments[fragment]))
+    if (!rec) throw mkError(404, `${this.upperName} not found.`)
+    return rec
+  }
+
+  async list ({ limit, offset, ...where } = {}, opts = {}) {
+    let { prisma, lowerPluralName } = this
+    let fragment = opts.fragment || this.defaultFragmentKey
+    where = formatRelationshipsIn(where)
+    const query = { where }
+    if (limit) query.first = limit
+    if (offset) query.skip = offset
+    let promises = [
+      prisma[lowerPluralName](query).$fragment(this.fragments[fragment])
+    ]
+    promises.push(opts.includeTotal
+      ? prisma[`${lowerPluralName}Connection`]({ where }).aggregate().count()
+      : Promise.resolve()
+    )
+    return Promise.all(promises)
+  }
+
+  async create (data, opts = {}) {
+    let fragment = opts.fragment || this.defaultFragmentKey
+    data = formatInputData(data)
+    return this.prisma[`create${this.upperName}`](data).$fragment(this.fragments[fragment])
+  }
+
+  async update (uniqueKeyObj, data, opts = {}) {
+    let fragment = opts.fragment || this.defaultFragmentKey
+    data = formatInputData(data)
+    return this.prisma[`update${this.upperName}`]({ data, where: uniqueKeyObj }).$fragment(this.fragments[fragment])
+  }
+
+  async remove (uniqueKeyObj) {
+    return onFail(400, () => this.prisma[`delete${this.upperName}`](uniqueKeyObj))
+  }
+}

--- a/lib/prisma-cache/src/utils.js
+++ b/lib/prisma-cache/src/utils.js
@@ -1,0 +1,80 @@
+// Config access.
+const R = require('ramda')
+const { prune } = require('dead-leaves')
+
+function mkError (status, err) {
+  if (typeof err === 'string') err = new Error(err)
+  err.status = err.statusCode = status
+  throw err
+}
+
+async function onFail (status, action) {
+  try {
+    const result = await action()
+    return result
+  }
+  catch (err) {
+    throw mkError(status, err)
+  }
+}
+
+function lowerFirst (x) {
+  return `${x.charAt(0).toLowerCase()}${x.slice(1)}`
+}
+
+function upperFirst (x) {
+  return `${x.charAt(0).toUpperCase()}${x.slice(1)}`
+}
+
+function formatRelationshipsIn (data) {
+  const REF_PROP_RE = /^(.+)(Id|ID)$/
+  return R.keys(data).reduce((acc, x) => {
+    if (!REF_PROP_RE.test(x)) return R.assoc(x, data[x], acc)
+    if (data[x] == null) return acc
+    return R.assoc(x.replace(/(Id|ID)$/, ''), { id: data[x] }, acc)
+  }, {})
+}
+
+function isRelationshipRef (val) {
+  return val && typeof val === 'object' && 'id' in val && R.keys(val).length === 1
+}
+
+function formatRelationshipsOut (data) {
+  return R.keys(data).reduce((acc, x) => {
+    if (isRelationshipRef(data[x])) {
+      return R.assoc(`${x}Id`, data[x].id, acc)
+    }
+    return R.assoc(x, data[x], acc)
+  }, {})
+}
+
+function connectRelationshipReferences (data) {
+  return R.keys(data).reduce((acc, x) => {
+    if (isRelationshipRef(acc[x])) {
+      acc[x] = { connect: acc[x] }
+    }
+    return acc
+  }, data)
+}
+
+function formatInputPruneFilter (x) {
+  return typeof x !== 'undefined'
+}
+
+// remove any undefined properties, then format the reference connections
+const formatInputData = R.compose(
+  connectRelationshipReferences,
+  formatRelationshipsIn,
+  x => prune(x, formatInputPruneFilter)
+)
+
+module.exports = {
+  mkError,
+  onFail,
+  lowerFirst,
+  upperFirst,
+  formatRelationshipsIn,
+  formatRelationshipsOut,
+  connectRelationshipReferences,
+  formatInputData
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5749,6 +5749,11 @@
         }
       }
     },
+    "object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
+    },
     "object-sizeof": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object-sizeof/-/object-sizeof-1.3.0.tgz",
@@ -8449,7 +8454,7 @@
         "node-fetch": "^1.7.3",
         "node-pre-gyp": "^0.11.0",
         "source-map-support": "^0.4.17",
-        "ttnapi": "git+https://github.com/thethingsnetwork/api.git#d844e8c040fcf3c80e0b31f4c707e69974bc71b5"
+        "ttnapi": "git+https://github.com/thethingsnetwork/api.git"
       },
       "dependencies": {
         "debug": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "mkdirp": "~0.5.1",
     "morgan": "^1.9.1",
     "nodemailer": "^4.7.0",
+    "object-hash": "^1.3.1",
     "object-sizeof": "^1.3.0",
     "passport": "^0.4.0",
     "passport-local": "^1.0.0",

--- a/rest/lib/utils.js
+++ b/rest/lib/utils.js
@@ -62,6 +62,14 @@ const getHttpRequestPreferedWaitMs = R.compose(
 
 const normalizeDevEUI = R.replace(/[^0-9A-Fa-f]/g, '')
 
+function lowerFirst (x) {
+  return `${x.charAt(0).toLowerCase()}${x.slice(1)}`
+}
+
+function upperFirst (x) {
+  return `${x.charAt(0).toUpperCase()}${x.slice(1)}`
+}
+
 module.exports = {
   mutate,
   onFail,
@@ -72,5 +80,7 @@ module.exports = {
   normalizeFilePath,
   getCertificateCn,
   getHttpRequestPreferedWaitMs,
-  normalizeDevEUI
+  normalizeDevEUI,
+  lowerFirst,
+  upperFirst
 }

--- a/rest/lib/utils.js
+++ b/rest/lib/utils.js
@@ -70,6 +70,16 @@ function upperFirst (x) {
   return `${x.charAt(0).toUpperCase()}${x.slice(1)}`
 }
 
+const parseProp = R.curry(function parseProp (prop, data) {
+  if (!data[prop] || typeof data[prop] !== 'string') return data
+  return { ...data, [prop]: JSON.parse(data[prop]) }
+})
+
+const stringifyProp = R.curry(function stringifyProp (prop, data) {
+  if (!data[prop] || typeof data[prop] === 'string') return data
+  return { ...data, [prop]: JSON.stringify(data[prop]) }
+})
+
 module.exports = {
   mutate,
   onFail,
@@ -82,5 +92,7 @@ module.exports = {
   getHttpRequestPreferedWaitMs,
   normalizeDevEUI,
   lowerFirst,
-  upperFirst
+  upperFirst,
+  parseProp,
+  stringifyProp
 }

--- a/rest/models/IApplication.js
+++ b/rest/models/IApplication.js
@@ -47,6 +47,7 @@ const DB = new CacheFirstStrategy({
 // ******************************************************************************
 const renameEnabledToRunning = renameKeys({ enabled: 'running' })
 const renameRunningToEnabled = renameKeys({ running: 'enabled' })
+const renameQueryKeys = renameKeys({ search: 'name_contains' })
 
 // ******************************************************************************
 // Model
@@ -71,10 +72,7 @@ class Application {
   }
 
   async list (query = {}, opts) {
-    if (query.search) {
-      query = renameKeys({ search: 'name_contains' }, query)
-    }
-    let [ records, totalCount ] = await DB.list(query, opts)
+    let [ records, totalCount ] = await DB.list(renameQueryKeys(query), opts)
     return [ records.map(renameEnabledToRunning), totalCount ]
   }
 

--- a/rest/models/IApplication.js
+++ b/rest/models/IApplication.js
@@ -1,137 +1,11 @@
 const appLogger = require('../lib/appLogger.js')
 const NetworkProtocolDataAccess = require('../networkProtocols/networkProtocolDataAccess.js')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 var httpError = require('http-errors')
-const { onFail, renameKeys } = require('../lib/utils')
+const { renameKeys } = require('../lib/utils')
 const R = require('ramda')
-
-class Application {
-  constructor (modelAPI) {
-    this.modelAPI = modelAPI
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    let [records, totalCount] = await Promise.all([
-      prisma.applications(query).$fragment(fragments.basic),
-      prisma.applicationsConnection({ where }).aggregate().count()
-    ])
-    records = records.map(renameEnabledToRunning)
-    return { totalCount, records }
-  }
-
-  async load (id, fragment) {
-    const app = await loadApplication({ id }, fragment)
-    try {
-      const { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: id })
-      if (records.length) {
-        app.networks = records.map(x => x.networkType.id)
-      }
-    }
-    catch (err) {
-      // ignore
-    }
-    return renameEnabledToRunning(app)
-  }
-
-  create (data) {
-    if (data.running) {
-      data.enabled = data.running
-      delete data.running
-    }
-    data = formatInputData(data)
-    return prisma.createApplication(data).$fragment(fragments.basic)
-  }
-
-  update ({ id, ...data }) {
-    // Throw away running prop, if present
-    if (!id) throw httpError(400, 'No existing Application ID')
-    data = formatInputData(R.omit(['running'], data))
-    return prisma.updateApplication({ data, where: { id } }).$fragment(fragments.basic)
-  }
-
-  async remove (id) {
-    // Delete devices
-    try {
-      let { records } = await this.modelAPI.devices.list({ applicationId: id })
-      await Promise.all(records.map(x => this.modelAPI.devices.remove(x.id)))
-    }
-    catch (err) {
-      appLogger.log(`Error deleting application's devices: ${err}`, 'error')
-    }
-    // Delete applicationNetworkTypeLinks
-    try {
-      let { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: id })
-      await Promise.all(records.map(x => this.modelAPI.applicationNetworkTypeLinks.remove(x.id)))
-    }
-    catch (err) {
-      appLogger.log(`Error deleting application's networkTypeLinks: ${err}`, 'error')
-    }
-    const app = await loadApplication({ id })
-    // Kill the application if it's running.
-    if (app.enabled) await this.stopApplication(id, false)
-    // Delete application record
-    return onFail(400, () => prisma.deleteApplication({ id }))
-  }
-
-  async startApplication (id) {
-    // Ensure app has baseUrl
-    let app = await loadApplication({ id })
-    if (!app.baseUrl) {
-      throw httpError(400, 'Base URL required to start application.')
-    }
-    app = await prisma.updateApplication({ data: { enabled: true }, where: { id } }).$fragment(fragments.basic)
-    // Call startApplication on NetworkTypes
-    let { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ application: { id } })
-    const logs = await Promise.all(records.map(x => this.modelAPI.networkTypeAPI.startApplication(x.networkType.id, id)))
-    return R.flatten(logs)
-  }
-
-  async stopApplication (id, update = true) {
-    if (update) await prisma.updateApplication({ data: { enabled: false }, where: { id } })
-    // Call stopApplication on NetworkTypes
-    let { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ application: { id } })
-    const logs = await Promise.all(records.map(x => this.modelAPI.networkTypeAPI.stopApplication(x.networkType.id, id)))
-    return R.flatten(logs)
-  }
-
-  async testApplication (id, data) {
-    try {
-      const app = await loadApplication({ id })
-      const reportingProtocol = await this.modelAPI.reportingProtocols.getHandler(app.reportingProtocol.id)
-      let response = await reportingProtocol.report(data, app.baseUrl, app.name)
-      return response.statusCode
-    }
-    catch (err) {
-      appLogger.log('Failed test, error = ' + err)
-      throw err
-    }
-  }
-
-  async passDataToApplication (id, networkId, data) {
-    // Ensure application is running
-    const app = await loadApplication({ id })
-    if (!app.enabled) return
-    // Ensure network is enabled
-    const network = await this.modelAPI.networks.load(networkId)
-    if (!network.securityData.enabled) return
-    // Ensure applicationNetworkTypeLink exists
-    const appNtlQuery = { application: { id }, networkType: { id: network.networkType.id }, limit: 1 }
-    let { records } = await this.modelAPI.applicationNetworkTypeLinks.list(appNtlQuery)
-    if (!records.length) return
-    // Pass data
-    let proto = await this.modelAPI.networkProtocolAPI.getProtocol(network)
-    let dataAPI = new NetworkProtocolDataAccess(this.modelAPI, 'ReportingProtocol')
-    await proto.passDataToApplication(network, id, data, dataAPI)
-  }
-}
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const { redisClient } = require('../lib/redis')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -156,11 +30,139 @@ const fragments = {
 }
 
 // ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'application',
+  pluralName: 'applications',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
 // Helpers
 // ******************************************************************************
 const renameEnabledToRunning = renameKeys({ enabled: 'running' })
+const renameRunningToEnabled = renameKeys({ running: 'enabled' })
 
-const loadApplication = loadRecord('application', fragments, 'basic')
+// ******************************************************************************
+// Model
+// ******************************************************************************
+class Application {
+  constructor (modelAPI) {
+    this.modelAPI = modelAPI
+  }
+
+  async load (id, opts) {
+    const app = await DB.load({ id }, opts)
+    try {
+      const [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: id })
+      if (records.length) {
+        app.networks = records.map(x => x.networkType.id)
+      }
+    }
+    catch (err) {
+      // ignore
+    }
+    return renameEnabledToRunning(app)
+  }
+
+  async list (query = {}, opts) {
+    if (query.search) {
+      query = renameKeys({ search: 'name_contains' }, query)
+    }
+    let [ records, totalCount ] = await DB.list(query, opts)
+    return [ records.map(renameEnabledToRunning), totalCount ]
+  }
+
+  create (data) {
+    return DB.create(renameRunningToEnabled(data))
+  }
+
+  update ({ id, ...data }, opts) {
+    // Throw away running prop, if present
+    if (!id) throw httpError(400, 'No existing Application ID')
+    return DB.update({ id }, R.omit(['running', 'enabled'], data), opts)
+  }
+
+  async remove (id) {
+    // Delete devices
+    try {
+      let [ records ] = await this.modelAPI.devices.list({ applicationId: id })
+      await Promise.all(records.map(x => this.modelAPI.devices.remove(x.id)))
+    }
+    catch (err) {
+      appLogger.log(`Error deleting application's devices: ${err}`, 'error')
+    }
+    // Delete applicationNetworkTypeLinks
+    try {
+      let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: id })
+      await Promise.all(records.map(x => this.modelAPI.applicationNetworkTypeLinks.remove(x.id)))
+    }
+    catch (err) {
+      appLogger.log(`Error deleting application's networkTypeLinks: ${err}`, 'error')
+    }
+    const app = DB.load({ id })
+    // Kill the application if it's running.
+    if (app.enabled) await this.stopApplication(id, false)
+    // Delete application record
+    await DB.remove({ id })
+  }
+
+  async startApplication (id) {
+    // Ensure app has baseUrl
+    let app = await DB.load({ id })
+    if (!app.baseUrl) {
+      throw httpError(400, 'Base URL required to start application.')
+    }
+    await DB.update({ id }, { enabled: true })
+    // Call startApplication on NetworkTypes
+    let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ application: { id } })
+    const logs = await Promise.all(records.map(x => this.modelAPI.networkTypeAPI.startApplication(x.networkType.id, id)))
+    return R.flatten(logs)
+  }
+
+  async stopApplication (id, update = true) {
+    if (update) await DB.update({ id }, { enabled: false })
+    // Call stopApplication on NetworkTypes
+    let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ application: { id } })
+    const logs = await Promise.all(records.map(x => this.modelAPI.networkTypeAPI.stopApplication(x.networkType.id, id)))
+    return R.flatten(logs)
+  }
+
+  async testApplication (id, data) {
+    try {
+      const app = await DB.load({ id })
+      const reportingProtocol = await this.modelAPI.reportingProtocols.getHandler(app.reportingProtocol.id)
+      let response = await reportingProtocol.report(data, app.baseUrl, app.name)
+      return response.statusCode
+    }
+    catch (err) {
+      appLogger.log('Failed test, error = ' + err)
+      throw err
+    }
+  }
+
+  async passDataToApplication (id, networkId, data) {
+    // Ensure application is running
+    const app = await DB.load({ id })
+    if (!app.enabled) return
+    // Ensure network is enabled
+    const network = await this.modelAPI.networks.load(networkId)
+    if (!network.securityData.enabled) return
+    // Ensure applicationNetworkTypeLink exists
+    const appNtlQuery = { application: { id }, networkType: { id: network.networkType.id }, limit: 1 }
+    let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list(appNtlQuery)
+    if (!records.length) return
+    // Pass data
+    let proto = await this.modelAPI.networkProtocolAPI.getProtocol(network)
+    let dataAPI = new NetworkProtocolDataAccess(this.modelAPI, 'ReportingProtocol')
+    await proto.passDataToApplication(network, id, data, dataAPI)
+  }
+}
 
 //* *****************************************************************************
 // Exports

--- a/rest/models/IApplicationNetworkTypeLink.js
+++ b/rest/models/IApplicationNetworkTypeLink.js
@@ -1,11 +1,50 @@
 var appLogger = require('../lib/appLogger.js')
 var httpError = require('http-errors')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
-const { onFail } = require('../lib/utils')
+const { prisma } = require('../lib/prisma')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const { redisClient } = require('../lib/redis')
 
+//* *****************************************************************************
+// Fragments for how the data should be returned from Prisma.
+//* *****************************************************************************
+const fragments = {
+  basic: `fragment BasicApplicationNetworkTypeLink on ApplicationNetworkTypeLink {
+    id
+    networkSettings
+    application {
+      id
+    }
+    networkType {
+      id
+    }
+  }`
+}
+
+// ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'applicationNetworkTypeLink',
+  pluralName: 'applicationNetworkTypeLinks',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
 module.exports = class ApplicationNetworkTypeLink {
   constructor (modelAPI) {
     this.modelAPI = modelAPI
+    this.list = DB.list.bind(DB)
+  }
+
+  async load (id, opts) {
+    const rec = await DB.load({ id }, opts)
+    return { ...rec, networkSettings: JSON.parse(rec.networkSettings) }
   }
 
   async create (data, { companyId, remoteOrigin = false } = {}) {
@@ -13,11 +52,8 @@ module.exports = class ApplicationNetworkTypeLink {
       if (companyId) {
         await this.validateCompanyForApplication(companyId, data.applicationId)
       }
-      const recData = formatInputData({
-        ...data,
-        networkSettings: JSON.stringify(data.networkSettings)
-      })
-      const rec = await prisma.createApplicationNetworkTypeLink(recData).$fragment(fragments.basic)
+      const recData = { ...data, networkSettings: JSON.stringify(data.networkSettings) }
+      const rec = await DB.create(recData)
       if (!remoteOrigin) {
         const logs = await this.modelAPI.networkTypeAPI.addApplication(rec.networkType.id, rec.application.id, data.networkSettings)
         rec.remoteAccessLogs = logs
@@ -30,35 +66,13 @@ module.exports = class ApplicationNetworkTypeLink {
     }
   }
 
-  async load (id) {
-    const rec = await loadApplicationNTL({ id })
-    return { ...rec, networkSettings: JSON.parse(rec.networkSettings) }
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    let [records, totalCount] = await Promise.all([
-      prisma.applicationNetworkTypeLinks(query).$fragment(fragments.basic),
-      prisma.applicationNetworkTypeLinksConnection({ where }).aggregate().count()
-    ])
-    records = records.map(x => ({
-      ...x,
-      networkSettings: JSON.parse(x.networkSettings)
-    }))
-    return { totalCount, records }
-  }
-
   async update ({ id, ...data }, { companyId, remoteOrigin = false } = {}) {
     try {
       await this.validateCompanyForApplicationNetworkTypeLink(companyId, id)
       if (typeof data.networkSettings !== 'string') {
         data.networkSettings = JSON.stringify(data.networkSettings)
       }
-      data = formatInputData(data)
-      const rec = await prisma.updateApplicationNetworkTypeLink({ data, where: { id } }).$fragment(fragments.basic)
+      const rec = await DB.update({ id }, data)
       if (!remoteOrigin) {
         const app = await this.modelAPI.applications.load(rec.application.id)
         var logs = await this.modelAPI.networkTypeAPI.pushApplication(rec.networkType.id, app)
@@ -75,16 +89,16 @@ module.exports = class ApplicationNetworkTypeLink {
   async remove (id, { companyId } = {}) {
     await this.validateCompanyForApplicationNetworkTypeLink(companyId, id)
     try {
-      var rec = await this.load(id)
+      var rec = await DB.load({ id })
       // Delete devicenetworkTypeLinks
-      const { records: devices } = await this.modelAPI.devices.list({ applicationId: rec.application.id })
+      const [ devices ] = await this.modelAPI.devices.list({ applicationId: rec.application.id })
       const dntlQuery = { device: { id_in: devices.map(x => x.id) } }
-      let { records: deviceNtls } = await this.modelAPI.deviceNetworkTypeLinks.list(dntlQuery)
+      let [ deviceNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list(dntlQuery)
       await Promise.all(deviceNtls.map(x => this.modelAPI.deviceNetworkTypeLinks.remove(x.id)))
 
       // Don't delete the local record until the remote operations complete.
       var logs = await this.modelAPI.networkTypeAPI.deleteApplication(rec.networkType.id, rec.application.id)
-      await onFail(400, () => prisma.deleteApplicationNetworkTypeLink({ id }))
+      await DB.remove({ id })
       return logs
     }
     catch (err) {
@@ -97,7 +111,7 @@ module.exports = class ApplicationNetworkTypeLink {
     try {
       var rec = await this.load(id)
       // push devicenetworkTypeLinks
-      let { records: deviceNtls } = await this.modelAPI.deviceNetworkTypeLinks.list({ applicationId: rec.application.id })
+      let [ deviceNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ applicationId: rec.application.id })
       await Promise.all(deviceNtls.map(x => this.modelAPI.deviceNetworkTypeLinks.pushDeviceNetworkTypeLink(x.id)))
       var logs = await this.modelAPI.networkTypeAPI.pushApplication(rec.networkType.id, rec.application.id, rec.networkSettings)
       rec.remoteAccessLogs = logs
@@ -138,24 +152,3 @@ module.exports = class ApplicationNetworkTypeLink {
     }
   }
 }
-
-//* *****************************************************************************
-// Fragments for how the data should be returned from Prisma.
-//* *****************************************************************************
-const fragments = {
-  basic: `fragment BasicApplicationNetworkTypeLink on ApplicationNetworkTypeLink {
-    id
-    networkSettings
-    application {
-      id
-    }
-    networkType {
-      id
-    }
-  }`
-}
-
-// ******************************************************************************
-// Helpers
-// ******************************************************************************
-const loadApplicationNTL = loadRecord('applicationNetworkTypeLink', fragments, 'basic')

--- a/rest/models/ICompanyNetworkTypeLink.js
+++ b/rest/models/ICompanyNetworkTypeLink.js
@@ -1,25 +1,72 @@
 var appLogger = require('../lib/appLogger.js')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
-const { onFail } = require('../lib/utils')
-var httpError = require('http-errors')
-
-// var protocolDataAccess = require('../networkProtocols/networkProtocolDataAccess')
-
+const { prisma } = require('../lib/prisma')
 const R = require('ramda')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const { redisClient } = require('../lib/redis')
 
+//* *****************************************************************************
+// Fragments for how the data should be returned from Prisma.
+//* *****************************************************************************
+const fragments = {
+  basic: `fragment BasicCompanyNetworkTypeLink on CompanyNetworkTypeLink {
+    id
+    networkSettings
+    company {
+      id
+    }
+    networkType {
+      id
+    }
+  }`
+}
+
+// ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'companyNetworkTypeLink',
+  pluralName: 'companyNetworkTypeLinks',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Helpers
+// ******************************************************************************
+function parseNetworkSettings (x) {
+  return typeof x.networkSettings === 'string'
+    ? { ...x, networkSettings: JSON.parse(x.networkSettings) }
+    : x
+}
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
 module.exports = class CompanyNetworkTypeLink {
   constructor (modelAPI) {
     this.modelAPI = modelAPI
   }
 
+  load (id) {
+    return DB.load({ id })
+  }
+
+  async list (query, opts) {
+    let [ records, totalCount ] = await DB.list(query, opts)
+    return [ records.map(parseNetworkSettings), totalCount ]
+  }
+
   async create (companyId, networkTypeId, networkSettings, { remoteOrigin = false } = {}) {
     try {
-      const data = formatInputData({
+      const data = {
         companyId,
         networkTypeId,
         networkSettings: networkSettings && JSON.stringify(networkSettings)
-      })
-      const rec = await prisma.createCompanyNetworkTypeLink(data).$fragment(fragments.basic)
+      }
+      const rec = await DB.create(data)
       if (!remoteOrigin) {
         var logs = await this.modelAPI.networkTypeAPI.addCompany(networkTypeId, companyId, networkSettings)
         rec.remoteAccessLogs = logs
@@ -32,17 +79,14 @@ module.exports = class CompanyNetworkTypeLink {
     }
   }
 
-  load (id) {
-    return loadCompanyNTL({ id })
-  }
+
 
   async update ({ id, ...data }, { remoteOrigin = false } = {}) {
     try {
       if (data.networkSettings) {
         data.networkSettings = JSON.stringify(data.networkSettings)
       }
-      data = formatInputData(data)
-      const rec = await prisma.updateCompanyNetworkTypeLink({ data, where: { id } }).$fragment(fragments.basic)
+      const rec = await DB.update({ id }, data)
       if (!remoteOrigin) {
         var logs = await this.modelAPI.networkTypeAPI.pushCompany(rec.networkType.id, rec.company.id, rec.networkSettings)
         rec.remoteAccessLogs = logs
@@ -59,11 +103,11 @@ module.exports = class CompanyNetworkTypeLink {
     try {
       var rec = await this.load(id)
       // Delete applicationNetworkTypeLinks
-      let { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ companyId: rec.company.id })
+      let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ companyId: rec.company.id })
       await Promise.all(records.map(x => this.modelAPI.applicationNetworkTypeLinks.remove(x.id)))
       // Don't delete the local record until the remote operations complete.
       var logs = await this.modelAPI.networkTypeAPI.deleteCompany(rec.networkType.id, rec.company.id)
-      await onFail(400, () => prisma.deleteCompanyNetworkTypeLink({ id }))
+      await DB.remove({ id })
       return logs
     }
     catch (err) {
@@ -76,7 +120,7 @@ module.exports = class CompanyNetworkTypeLink {
     try {
       var rec = await this.load(id)
       // push applicationNetworkTypeLinks
-      let { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ companyId: rec.company.id })
+      let [ records ] = await this.modelAPI.applicationNetworkTypeLinks.list({ companyId: rec.company.id })
       await Promise.all(records.map(x => this.modelAPI.applicationNetworkTypeLinks.pushApplicationNetworkTypeLink(x.id)))
       var logs = await this.modelAPI.networkTypeAPI.pushCompany(rec.networkType.id, rec.company.id, rec.networkSettings)
       rec.remoteAccessLogs = logs
@@ -88,19 +132,8 @@ module.exports = class CompanyNetworkTypeLink {
     }
   }
 
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    const [records, totalCount] = await Promise.all([
-      prisma.companyNetworkTypeLinks(query).$fragment(fragments.basic),
-      prisma.companyNetworkTypeLinksConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records: records.map(parseNetworkSettings) }
-  }
-
   async pullCompanyNetworkTypeLink (networkTypeId) {
+    let existingCompany
     try {
       var logs = await this.modelAPI.networkTypeAPI.pullCompany(networkTypeId)
       let companies = JSON.parse(logs[Object.keys(logs)[0]].logs)
@@ -113,10 +146,10 @@ module.exports = class CompanyNetworkTypeLink {
         nsCoId.push(company.id)
 
         // see if it exists first
-        let existingCompany = await this.modelAPI.companies.list({ search: company.name })
-        if (existingCompany.totalCount > 0) {
-          existingCompany = existingCompany.records[0]
+        let [existingCompanies] = await this.modelAPI.companies.list({ search: company.name })
+        if (!existingCompanies.length) {
           appLogger.log(company.name + ' already exists')
+          existingCompany = existingCompanies[0]
           localCoId.push(existingCompany.id)
         }
         else {
@@ -125,8 +158,8 @@ module.exports = class CompanyNetworkTypeLink {
           localCoId.push(existingCompany.id)
         }
         // see if it exists first
-        let existingCompanyNTL = await this.modelAPI.companyNetworkTypeLinks.list({ companyId: existingCompany.id })
-        if (existingCompanyNTL.totalCount > 0) {
+        let [ctls] = await this.list({ companyId: existingCompany.id }, { limit: 1 })
+        if (ctls.length) {
           appLogger.log(company.name + ' link already exists')
         }
         else {
@@ -144,9 +177,10 @@ module.exports = class CompanyNetworkTypeLink {
         nsAppId.push(application.id)
 
         // see if it exists first
-        let existingApplication = await this.modelAPI.applications.list({ search: application.name })
-        if (existingApplication.totalCount > 0) {
-          existingApplication = existingApplication.records[0]
+        let existingApplication
+        let [appList] = await this.modelAPI.applications.list({ search: application.name })
+        if (appList.length) {
+          existingApplication = appList[0]
           localAppId.push(existingApplication.id)
           appLogger.log(application.name + ' already exists')
         }
@@ -163,8 +197,8 @@ module.exports = class CompanyNetworkTypeLink {
           localAppId.push(existingApplication.id)
         }
         // see if it exists first
-        let existingApplicationNTL = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: existingApplication.id })
-        if (existingApplicationNTL.totalCount > 0) {
+        let [ existingApps ] = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: existingApplication.id })
+        if (existingApps.length) {
           appLogger.log(application.name + ' link already exists')
         }
         else {
@@ -180,6 +214,7 @@ module.exports = class CompanyNetworkTypeLink {
       let nsDpId = []
       let localDpId = []
       for (var index in deviceProfiles.result) {
+        let existingDeviceProfile
         let deviceProfile = deviceProfiles.result[index]
         nsDpId.push(deviceProfile.deviceProfileID)
         let networkSettings = await this.modelAPI.networkTypeAPI.pullDeviceProfile(networkTypeId, deviceProfile.deviceProfileID)
@@ -187,9 +222,9 @@ module.exports = class CompanyNetworkTypeLink {
         networkSettings = networkSettings.deviceProfile
 
         // see if it exists first
-        let existingDeviceProfile = await this.modelAPI.deviceProfiles.list({ search: deviceProfile.name })
-        if (existingDeviceProfile.totalCount > 0) {
-          existingDeviceProfile = existingDeviceProfile.records[0]
+        let [ existingDeviceProfiles ] = await this.modelAPI.deviceProfiles.list({ search: deviceProfile.name, limit: 1 })
+        if (existingDeviceProfiles.length) {
+          existingDeviceProfile = existingDeviceProfiles[0]
           localDpId.push(existingDeviceProfile.id)
           appLogger.log(deviceProfile.name + ' ' + existingDeviceProfile.id + ' already exists')
           appLogger.log(JSON.stringify(existingDeviceProfile))
@@ -207,6 +242,7 @@ module.exports = class CompanyNetworkTypeLink {
       }
 
       for (var appIndex in nsAppId) {
+        let existingDevice
         logs = await this.modelAPI.networkTypeAPI.pullDevices(networkTypeId, nsAppId[appIndex])
         let devices = JSON.parse(logs[Object.keys(logs)[0]].logs)
         appLogger.log(JSON.stringify(devices))
@@ -214,9 +250,9 @@ module.exports = class CompanyNetworkTypeLink {
           let device = devices.result[index]
 
           // see if it exists first
-          let existingDevice = await this.modelAPI.devices.list({ search: device.name })
-          if (existingDevice.totalCount > 0) {
-            existingDevice = existingDevice.records[0]
+          let [ existingDevices ] = await this.modelAPI.devices.list({ search: device.name })
+          if (existingDevices.length) {
+            existingDevice = existingDevices[0]
             appLogger.log(device.name + ' already exists')
             await existingDevice.updateDevice(existingDevice)
           }
@@ -227,8 +263,8 @@ module.exports = class CompanyNetworkTypeLink {
             existingDevice = await this.modelAPI.devices.create(device.name, device.description, localAppId[appIndex])
           }
 
-          let existingDeviceNTL = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: existingDevice.id })
-          if (existingDeviceNTL.totalCount > 0) {
+          let [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: existingDevice.id })
+          if (devNtls.length) {
             appLogger.log(device.name + ' link already exists')
           }
           else {
@@ -252,29 +288,3 @@ module.exports = class CompanyNetworkTypeLink {
     }
   }
 }
-
-//* *****************************************************************************
-// Fragments for how the data should be returned from Prisma.
-//* *****************************************************************************
-const fragments = {
-  basic: `fragment BasicCompanyNetworkTypeLink on CompanyNetworkTypeLink {
-    id
-    networkSettings
-    company {
-      id
-    }
-    networkType {
-      id
-    }
-  }`
-}
-
-// ******************************************************************************
-// Helpers
-// ******************************************************************************
-function parseNetworkSettings (x) {
-  return typeof x.networkSettings === 'string'
-    ? { ...x, networkSettings: JSON.parse(x.networkSettings) }
-    : x
-}
-const loadCompanyNTL = loadRecord('companyNetworkTypeLink', fragments, 'basic')

--- a/rest/models/IDevice.js
+++ b/rest/models/IDevice.js
@@ -1,33 +1,64 @@
 const appLogger = require('../lib/appLogger.js')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 var httpError = require('http-errors')
-const { onFail, normalizeDevEUI } = require('../lib/utils')
+const { normalizeDevEUI, renameKeys } = require('../lib/utils')
 const R = require('ramda')
 const Joi = require('@hapi/joi')
 const { redisClient, redisPub } = require('../lib/redis')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
 
+//* *****************************************************************************
+// Fragments for how the data should be returned from Prisma.
+//* *****************************************************************************
+const fragments = {
+  basic: `fragment BasicDevice on Device {
+    id
+    name
+    description
+    deviceModel
+    application {
+      id
+    }
+  }`
+}
+
+// ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'device',
+  pluralName: 'devices',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Helpers
+// ******************************************************************************
+const unicastDownlinkSchema = Joi.object().keys({
+  fCnt: Joi.number().integer().min(0).required(),
+  fPort: Joi.number().integer().min(1).required(),
+  data: Joi.string().when('jsonData', { is: Joi.exist(), then: Joi.optional(), otherwise: Joi.required() }),
+  jsonData: Joi.object().optional()
+})
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
 module.exports = class Device {
   constructor (modelAPI) {
     this.modelAPI = modelAPI
   }
 
-  create (name, description, applicationId, deviceModel) {
-    appLogger.log(`IDevice ${name}, ${description}, ${applicationId}, ${deviceModel}`)
-    const data = formatInputData({
-      name,
-      description,
-      applicationId,
-      deviceModel
-    })
-    return prisma.createDevice(data).$fragment(fragments.basic)
-  }
-
   async load (id) {
-    const dvc = await loadDevice({ id })
+    const dvc = await DB.load({ id })
     try {
-      const { records } = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: id })
-      if (records.length) {
-        dvc.networks = records.map(x => x.networkType.id)
+      const [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: id })
+      if (devNtls.length) {
+        dvc.networks = devNtls.map(x => x.networkType.id)
       }
     }
     catch (err) {
@@ -36,51 +67,46 @@ module.exports = class Device {
     return dvc
   }
 
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
+
+  async list (query = {}, opts) {
+    if (query.search) {
+      query = renameKeys({ search: 'name_contains' }, query)
     }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    const [records, totalCount] = await Promise.all([
-      prisma.devices(query).$fragment(fragments.basic),
-      prisma.devicesConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records }
+    return DB.list(query, opts)
+  }
+
+  create (name, description, applicationId, deviceModel) {
+    return DB.create({ name, description, applicationId, deviceModel })
   }
 
   update ({ id, ...data }) {
     if (!id) throw httpError(400, 'No existing Device ID')
-    data = formatInputData(data)
-    return prisma.updateDevice({ data, where: { id } }).$fragment(fragments.basic)
+    return DB.update({ id }, data)
   }
 
   async remove (id) {
     // Delete my deviceNetworkTypeLinks first.
     try {
-      let { records } = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: id })
-      await Promise.all(records.map(x => this.modelAPI.deviceNetworkTypeLinks.remove(x.id)))
+      let [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: id })
+      await Promise.all(devNtls.map(x => this.modelAPI.deviceNetworkTypeLinks.remove(x.id)))
     }
     catch (err) {
       appLogger.log(`Error deleting device-dependant networkTypeLinks: ${err}`)
     }
-    return onFail(400, () => prisma.deleteDevice({ id }))
+    return DB.remove({ id })
   }
 
   async passDataToDevice (id, data) {
     // check for required fields
     let { error } = Joi.validate(data, unicastDownlinkSchema)
     if (error) throw httpError(400, error.message)
-    const device = await loadDevice({ id })
+    const device = await DB.load({ id })
     const app = await this.modelAPI.applications.load(device.application.id)
     if (!app.running) return
     // Get all device networkType links
     const devNtlQuery = { device: { id } }
-    let { records } = await this.modelAPI.deviceNetworkTypeLinks.list(devNtlQuery)
-    const logs = await Promise.all(records.map(x => this.modelAPI.networkTypeAPI.passDataToDevice(x, app.id, id, data)))
+    let [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list(devNtlQuery)
+    const logs = await Promise.all(devNtls.map(x => this.modelAPI.networkTypeAPI.passDataToDevice(x, app.id, id, data)))
     return R.flatten(logs)
   }
 
@@ -129,17 +155,17 @@ module.exports = class Device {
     let nwkType = await this.modelAPI.networkTypes.loadByName('IP')
     // Ensure a deviceNTL exists
     const devNTLQuery = { networkType: { id: nwkType.id }, networkSettings_contains: devEUI }
-    let { records: devNTLs } = await this.modelAPI.deviceNetworkTypeLinks.list(devNTLQuery)
-    if (!devNTLs.length) return
-    const devNTL = devNTLs[0]
+    let [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list(devNTLQuery)
+    if (!devNtls.length) return
+    const devNTL = devNtls[0]
     // Get device
-    const device = await this.modelAPI.devices.load(devNTL.device.id)
+    const device = await this.load(devNTL.device.id)
     // Get application
     const app = await this.modelAPI.applications.load(device.application.id)
     // Ensure application is enabled
     if (!app.running) return
     // Pass data
-    let { records: nwkProtos } = await this.modelAPI.networkProtocols.list({ networkType: { id: nwkType.id } })
+    let [ nwkProtos ] = await this.modelAPI.networkProtocols.list({ networkType: { id: nwkType.id }, limit: 1 })
     const ipProtoHandler = await this.modelAPI.networkProtocols.getHandler(nwkProtos[0].id)
     await ipProtoHandler.passDataToApplication(app, device, devEUI, data)
     // Check for cached downlink messages
@@ -151,8 +177,6 @@ module.exports = class Device {
   async pushIpDeviceDownlink (devEUI, data) {
     devEUI = normalizeDevEUI(devEUI)
     data = JSON.stringify(data)
-    // TODO: dont push message if there are listeners to the channel
-    // In that case, just send data as the publish message
     const result = await redisClient.rpushAsync(`ip_downlinks:${devEUI}`, data)
     redisPub.publish(`downlink_received:${devEUI}`, '')
     return result
@@ -168,30 +192,3 @@ module.exports = class Device {
     return msgs.map(JSON.parse)
   }
 }
-
-//* *****************************************************************************
-// Fragments for how the data should be returned from Prisma.
-//* *****************************************************************************
-const fragments = {
-  basic: `fragment BasicDevice on Device {
-    id
-    name
-    description
-    deviceModel
-    application {
-      id
-    }
-  }`
-}
-
-// ******************************************************************************
-// Helpers
-// ******************************************************************************
-const loadDevice = loadRecord('device', fragments, 'basic')
-
-const unicastDownlinkSchema = Joi.object().keys({
-  fCnt: Joi.number().integer().min(0).required(),
-  fPort: Joi.number().integer().min(1).required(),
-  data: Joi.string().when('jsonData', { is: Joi.exist(), then: Joi.optional(), otherwise: Joi.required() }),
-  jsonData: Joi.object().optional()
-})

--- a/rest/models/IDeviceProfile.js
+++ b/rest/models/IDeviceProfile.js
@@ -1,23 +1,84 @@
 var appLogger = require('../lib/appLogger.js')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 var httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
+const { renameKeys } = require('../lib/utils')
+const { redisClient } = require('../lib/redis')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
 
+//* *****************************************************************************
+// Fragments for how the data should be returned from Prisma.
+//* *****************************************************************************
+const fragments = {
+  basic: `fragment BasicDeviceProfile on DeviceProfile {
+    id
+    name
+    description
+    networkSettings
+    company {
+      id
+    }
+    networkType {
+      id
+    }
+  }`
+}
+
+// ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'deviceProfile',
+  pluralName: 'deviceProfiles',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Helpers
+// ******************************************************************************
+function parseNetworkSettings (x) {
+  return typeof x.networkSettings === 'string'
+    ? { ...x, networkSettings: JSON.parse(x.networkSettings) }
+    : x
+}
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
 module.exports = class DeviceProfile {
   constructor (modelAPI) {
     this.modelAPI = modelAPI
   }
 
+  async load (id) {
+    return parseNetworkSettings(await DB.load({ id }))
+  }
+
+  async list (query = {}, opts) {
+    if (query.search) {
+      query = renameKeys({ search: 'name_contains' }, query)
+    }
+    let [ records, totalCount ] = await DB.list(query, opts)
+    records = records.map(x => ({
+      ...x,
+      networkSettings: JSON.parse(x.networkSettings)
+    }))
+    return [ records, totalCount ]
+  }
+
   async create (networkTypeId, companyId, name, description, networkSettings, { remoteOrigin = false } = {}) {
     try {
-      const data = formatInputData({
+      const data = {
         networkTypeId,
         companyId,
         name,
         description,
         networkSettings: JSON.stringify(networkSettings)
-      })
-      const rec = await prisma.createDeviceProfile(data).$fragment(fragments.basic)
+      }
+      const rec = await DB.create(data)
       if (!remoteOrigin) {
         var logs = await this.modelAPI.networkTypeAPI.addDeviceProfile(networkTypeId, rec.id)
         rec.remoteAccessLogs = logs
@@ -36,8 +97,7 @@ module.exports = class DeviceProfile {
       if (data.networkSettings) {
         data.networkSettings = JSON.stringify(data.networkSettings)
       }
-      data = formatInputData(data)
-      const rec = await prisma.updateDeviceProfile({ data, where: { id } }).$fragment(fragments.basic)
+      const rec = await DB.update({ id }, data)
       var logs = await this.modelAPI.networkTypeAPI.pushDeviceProfile(rec.networkType.id, id)
       rec.remoteAccessLogs = logs
       return rec
@@ -48,38 +108,13 @@ module.exports = class DeviceProfile {
     }
   }
 
-  async load (id) {
-    const rec = await loadDeviceProfile({ id })
-    return parseNetworkSettings(rec)
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    let [records, totalCount] = await Promise.all([
-      prisma.deviceProfiles(query).$fragment(fragments.basic),
-      prisma.deviceProfilesConnection({ where }).aggregate().count()
-    ])
-    records = records.map(x => ({
-      ...x,
-      networkSettings: JSON.parse(x.networkSettings)
-    }))
-    return { totalCount, records }
-  }
-
   async remove (id, validateCompanyId) {
     try {
       // Since we clear the remote networks before we delete the local
       // record, validate the company now, if required.  Also, we need the
       // networkTypeId from the record to delete it from the relevant
       // networks.  So get the record to start anyway.
-      var rec = await this.load(id)
+      var rec = await DB.load({ id })
 
       if (validateCompanyId && validateCompanyId !== rec.company.id) {
         throw new httpError.Unauthorized()
@@ -87,7 +122,7 @@ module.exports = class DeviceProfile {
 
       // Don't delete the local record until the remote operations complete.
       var logs = await this.modelAPI.networkTypeAPI.deleteDeviceProfile(rec.networkType.id, id)
-      await onFail(400, () => prisma.deleteDeviceProfile({ id }))
+      await DB.remove({ id })
       return logs
     }
     catch (err) {
@@ -109,32 +144,3 @@ module.exports = class DeviceProfile {
     }
   }
 }
-
-//* *****************************************************************************
-// Fragments for how the data should be returned from Prisma.
-//* *****************************************************************************
-const fragments = {
-  basic: `fragment BasicDeviceProfile on DeviceProfile {
-    id
-    name
-    description
-    networkSettings
-    company {
-      id
-    }
-    networkType {
-      id
-    }
-  }`
-}
-
-// ******************************************************************************
-// Helpers
-// ******************************************************************************
-function parseNetworkSettings (x) {
-  return typeof x.networkSettings === 'string'
-    ? { ...x, networkSettings: JSON.parse(x.networkSettings) }
-    : x
-}
-
-const loadDeviceProfile = loadRecord('deviceProfile', fragments, 'basic')

--- a/rest/models/INetwork.js
+++ b/rest/models/INetwork.js
@@ -49,6 +49,8 @@ const genNwkKey = function (networkId) {
   return 'nk' + networkId
 }
 
+const renameQueryKeys = renameKeys({ search: 'name_contains' })
+
 async function authorizeAndTest (network, modelAPI) {
   if (network.securityData.authorized) {
     return network
@@ -107,10 +109,7 @@ module.exports = class Network {
   }
 
   async list (query = {}, opts) {
-    if (query.search) {
-      query = renameKeys({ search: 'name_contains' }, query)
-    }
-    let [ records, totalCount ] = await DB.list(query, opts)
+    let [ records, totalCount ] = await DB.list(renameQueryKeys(query), opts)
     records = await Promise.all(records.map(async rec => {
       if (!rec.securityData) return rec
       let k = await this.modelAPI.protocolData.loadValue(rec, genNwkKey(rec.id))

--- a/rest/models/INetworkProtocol.js
+++ b/rest/models/INetworkProtocol.js
@@ -1,88 +1,11 @@
 const path = require('path')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 const httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
+const { renameKeys } = require('../lib/utils')
 const registerNetworkProtocols = require('../networkProtocols/register')
-
-const handlerDir = path.join(__dirname, '../networkProtocols/handlers')
-
-module.exports = class NetworkProtocol {
-  constructor () {
-    this.handlers = {}
-  }
-
-  async initialize (modelAPI) {
-    await registerNetworkProtocols(modelAPI)
-    const { records } = await this.list()
-    const handlersDir = path.join(__dirname, '../networkProtocols/handlers')
-    records.forEach(x => {
-      let Handler = require(path.join(handlersDir, x.protocolHandler))
-      this.handlers[x.id] = new Handler({ modelAPI, networkProtocolId: x.id })
-    })
-  }
-
-  async create (name, networkTypeId, protocolHandler, version, masterProtocolId) {
-    const data = formatInputData({
-      name,
-      protocolHandler,
-      networkProtocolVersion: version,
-      networkTypeId,
-      masterProtocolId
-    })
-    let rec = await prisma.createNetworkProtocol(data).$fragment(fragments.basic)
-    if (!masterProtocolId) {
-      rec = await this.update({ id: rec.id, masterProtocolId: rec.id })
-    }
-    return rec
-  }
-
-  async upsert ({ networkProtocolVersion, ...np }) {
-    const { records } = await this.list({ search: np.name, networkProtocolVersion })
-    if (records.length) {
-      return this.update({ id: records[0].id, ...np })
-    }
-    return this.create(np.name, np.networkTypeId, np.protocolHandler, networkProtocolVersion, np.masterProtocolId)
-  }
-
-  update ({ id, ...data }) {
-    if (!id) throw httpError(400, 'No existing NetworkProtocol ID')
-    data = formatInputData(data)
-    return prisma.updateNetworkProtocol({ data, where: { id } }).$fragment(fragments.basic)
-  }
-
-  load (id) {
-    return loadNetworkProtocol({ id })
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    if (where.networkProtocolVersion) {
-      where.networkProtocolVersion_contains = where.networkProtocolVersion
-      delete where.networkProtocolVersion
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    // if (Object.keys(where).length) {
-    const [records, totalCount] = await Promise.all([
-      prisma.networkProtocols(query).$fragment(fragments.basic),
-      prisma.networkProtocolsConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records: records.map(addMetadata) }
-  }
-
-  remove (id) {
-    return onFail(400, () => prisma.deleteNetworkProtocol({ id }))
-  }
-
-  getHandler (id) {
-    return this.handlers[id]
-  }
-}
+const { redisClient } = require('../lib/redis')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const appLogger = require('../lib/appLogger')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -103,8 +26,23 @@ const fragments = {
 }
 
 // ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'networkProtocol',
+  pluralName: 'networkProtocols',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
 // Helpers
 // ******************************************************************************
+const handlerDir = path.join(__dirname, '../networkProtocols/handlers')
+
 function addMetadata (rec) {
   return {
     ...rec,
@@ -112,4 +50,73 @@ function addMetadata (rec) {
   }
 }
 
-const loadNetworkProtocol = loadRecord('networkProtocol', fragments, 'basic')
+// ******************************************************************************
+// Model
+// ******************************************************************************
+module.exports = class NetworkProtocol {
+  constructor () {
+    this.handlers = {}
+  }
+
+  async initialize (modelAPI) {
+    await registerNetworkProtocols(modelAPI)
+    const [ nps ] = await this.list()
+    const handlersDir = path.join(__dirname, '../networkProtocols/handlers')
+    nps.forEach(x => {
+      let Handler = require(path.join(handlersDir, x.protocolHandler))
+      this.handlers[x.id] = new Handler({ modelAPI, networkProtocolId: x.id })
+    })
+  }
+
+  load (id) {
+    return DB.load({ id })
+  }
+
+  async list (query = {}, opts) {
+    let keyMap = {}
+    if (query.search) {
+      keyMap.search = 'name_contains'
+    }
+    if (query.networkProtocolVersion) {
+      keyMap.networkProtocolVersion = 'networkProtocolVersion_contains'
+    }
+    let [ records, totalCount ] = await DB.list(renameKeys(keyMap, query), opts)
+    return [records.map(addMetadata), totalCount]
+  }
+
+  async create (name, networkTypeId, protocolHandler, version, masterProtocolId) {
+    const data = {
+      name,
+      protocolHandler,
+      networkProtocolVersion: version,
+      networkTypeId,
+      masterProtocolId
+    }
+    let rec = await DB.create(data)
+    if (!masterProtocolId) {
+      rec = await this.update({ id: rec.id, masterProtocolId: rec.id })
+    }
+    return rec
+  }
+
+  update ({ id, ...data }) {
+    if (!id) throw httpError(400, 'No existing NetworkProtocol ID')
+    return DB.update({ id }, data)
+  }
+
+  async upsert ({ networkProtocolVersion, ...np }) {
+    const [nps] = await this.list({ search: np.name, networkProtocolVersion, limit: 1 })
+    if (nps.length) {
+      return this.update({ id: nps[0].id, ...np })
+    }
+    return this.create(np.name, np.networkTypeId, np.protocolHandler, networkProtocolVersion, np.masterProtocolId)
+  }
+
+  remove (id) {
+    return DB.remove({ id })
+  }
+
+  getHandler (id) {
+    return this.handlers[id]
+  }
+}

--- a/rest/models/INetworkProtocol.js
+++ b/rest/models/INetworkProtocol.js
@@ -49,6 +49,10 @@ function addMetadata (rec) {
     metaData: require(path.join(handlerDir, rec.protocolHandler, 'metadata'))
   }
 }
+const renameQueryKeys = renameKeys({
+  search: 'name_contains',
+  networkProtocolVersiona: 'networkProtocolVersion_contains'
+})
 
 // ******************************************************************************
 // Model
@@ -73,14 +77,7 @@ module.exports = class NetworkProtocol {
   }
 
   async list (query = {}, opts) {
-    let keyMap = {}
-    if (query.search) {
-      keyMap.search = 'name_contains'
-    }
-    if (query.networkProtocolVersion) {
-      keyMap.networkProtocolVersion = 'networkProtocolVersion_contains'
-    }
-    let [ records, totalCount ] = await DB.list(renameKeys(keyMap, query), opts)
+    let [ records, totalCount ] = await DB.list(renameQueryKeys(query), opts)
     return [records.map(addMetadata), totalCount]
   }
 

--- a/rest/models/INetworkProvider.js
+++ b/rest/models/INetworkProvider.js
@@ -29,6 +29,11 @@ const DB = new CacheFirstStrategy({
 })
 
 // ******************************************************************************
+// Helpers
+// ******************************************************************************
+const renameQueryKeys = renameKeys({ search: 'name_contains' })
+
+// ******************************************************************************
 // Model
 // ******************************************************************************
 module.exports = class NetworkProvider {
@@ -37,7 +42,7 @@ module.exports = class NetworkProvider {
   }
 
   async list (query = {}, opts) {
-    return DB.list(renameKeys({ search: 'name_contains' }, query), opts)
+    return DB.list(renameQueryKeys(query), opts)
   }
 
   create (name) {

--- a/rest/models/INetworkProvider.js
+++ b/rest/models/INetworkProvider.js
@@ -1,40 +1,9 @@
-const { prisma, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 const httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
-
-module.exports = class NetworkProvider {
-  create (name) {
-    return prisma.createNetworkProvider({ name })
-  }
-
-  update ({ id, ...data }) {
-    if (!id) throw httpError(400, 'No existing NetworkProvider ID')
-    return prisma.updateNetworkProvider({ data, where: { id } })
-  }
-
-  load (id) {
-    return loadNetworkProvider({ id })
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    const [records, totalCount] = await Promise.all([
-      prisma.networkProviders(query),
-      prisma.networkProvidersConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records }
-  }
-
-  remove (id) {
-    return onFail(400, () => prisma.deleteNetworkProvider({ id }))
-  }
-}
+const { renameKeys } = require('../lib/utils')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const appLogger = require('../lib/appLogger')
+const { redisClient } = require('../lib/redis')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -47,6 +16,40 @@ const fragments = {
 }
 
 // ******************************************************************************
-// Helpers
+// Database Client
 // ******************************************************************************
-const loadNetworkProvider = loadRecord('networkProvider', fragments, 'basic')
+const DB = new CacheFirstStrategy({
+  name: 'networkProvider',
+  pluralName: 'networkProviders',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
+module.exports = class NetworkProvider {
+  load (id) {
+    return DB.load({ id })
+  }
+
+  async list (query = {}, opts) {
+    return DB.list(renameKeys({ search: 'name_contains' }, query), opts)
+  }
+
+  create (name) {
+    return DB.create({ name })
+  }
+
+  update ({ id, ...data }) {
+    if (!id) throw httpError(400, 'No existing NetworkProvider ID')
+    return DB.update({ id }, data)
+  }
+
+  remove (id) {
+    return DB.remove({ id })
+  }
+}

--- a/rest/models/INetworkType.js
+++ b/rest/models/INetworkType.js
@@ -1,44 +1,9 @@
-const { prisma, loadRecord } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 const httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
-
-module.exports = class NetworkType {
-  create (name) {
-    return prisma.createNetworkType({ name })
-  }
-
-  update ({ id, ...data }) {
-    if (!id) throw httpError(400, 'No existing NetworkType ID')
-    return prisma.updateNetworkType({ data, where: { id } })
-  }
-
-  remove (id) {
-    return onFail(400, () => prisma.deleteNetworkType({ id }))
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    let [records, totalCount] = await Promise.all([
-      prisma.networkTypes(query).$fragment(fragments.basic),
-      prisma.networkTypesConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records }
-  }
-
-  load (id) {
-    return loadNetworkType({ id })
-  }
-
-  loadByName (name) {
-    return loadNetworkType({ name })
-  }
-}
+const { renameKeys } = require('../lib/utils')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+const appLogger = require('../lib/appLogger')
+const { redisClient } = require('../lib/redis')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -51,6 +16,44 @@ const fragments = {
 }
 
 // ******************************************************************************
-// Helpers
+// Database Client
 // ******************************************************************************
-const loadNetworkType = loadRecord('networkType', fragments, 'basic')
+const DB = new CacheFirstStrategy({
+  name: 'networkType',
+  pluralName: 'networkTypes',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
+module.exports = class NetworkType {
+  load (id) {
+    return DB.load({ id })
+  }
+
+  async list (query = {}, opts) {
+    return DB.list(renameKeys({ search: 'name_contains' }, query), opts)
+  }
+
+  create (name) {
+    return DB.create({ name })
+  }
+
+  update ({ id, ...data }) {
+    if (!id) throw httpError(400, 'No existing NetworkType ID')
+    return DB.update({ id }, data)
+  }
+
+  remove (id) {
+    return DB.remove({ id })
+  }
+
+  loadByName (name) {
+    return DB.load({ name })
+  }
+}

--- a/rest/models/INetworkType.js
+++ b/rest/models/INetworkType.js
@@ -29,6 +29,11 @@ const DB = new CacheFirstStrategy({
 })
 
 // ******************************************************************************
+// Helpers
+// ******************************************************************************
+const renameQueryKeys = renameKeys({ search: 'name_contains' })
+
+// ******************************************************************************
 // Model
 // ******************************************************************************
 module.exports = class NetworkType {
@@ -37,7 +42,7 @@ module.exports = class NetworkType {
   }
 
   async list (query = {}, opts) {
-    return DB.list(renameKeys({ search: 'name_contains' }, query), opts)
+    return DB.list(renameQueryKeys(query), opts)
   }
 
   create (name) {

--- a/rest/models/IReportingProtocol.js
+++ b/rest/models/IReportingProtocol.js
@@ -1,60 +1,10 @@
-const { prisma, loadRecord, formatRelationshipsIn } = require('../lib/prisma')
+const { prisma } = require('../lib/prisma')
 const httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
+const { renameKeys } = require('../lib/utils')
 const path = require('path')
-
-module.exports = class ReportingProtocol {
-  constructor () {
-    this.handlers = {}
-  }
-
-  async initialize () {
-    const { records } = await this.list()
-    const handlersDir = path.join(__dirname, '../reportingProtocols')
-    records.forEach(x => {
-      let Handler = require(path.join(handlersDir, x.protocolHandler))
-      this.handlers[x.id] = new Handler({ reportingProtocolId: x.id })
-    })
-  }
-
-  create (name, protocolHandler) {
-    const data = { name, protocolHandler }
-    return prisma.createReportingProtocol(data)
-  }
-
-  update ({ id, ...data }) {
-    if (!id) throw httpError(400, 'No existing ReportingProtocol ID')
-    return prisma.updateReportingProtocol({ data, where: { id } })
-  }
-
-  load (id) {
-    return loadReportingProtocol({ id })
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.name_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    const [records, totalCount] = await Promise.all([
-      prisma.reportingProtocols(query).$fragment(fragments.basic),
-      prisma.reportingProtocolsConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records }
-  }
-
-  remove (id) {
-    return onFail(400, () => prisma.deleteReportingProtocol({ id }))
-  }
-
-  getHandler (id) {
-    return this.handlers[id]
-  }
-}
+const { redisClient } = require('../lib/redis')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
+var appLogger = require('../lib/appLogger.js')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -68,6 +18,62 @@ const fragments = {
 }
 
 // ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'reportingProtocol',
+  pluralName: 'reportingProtocols',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
+// ******************************************************************************
 // Helpers
 // ******************************************************************************
-const loadReportingProtocol = loadRecord('reportingProtocol', fragments, 'basic')
+const renameQueryKeys = renameKeys({ search: 'name_contains' })
+
+// ******************************************************************************
+// Model
+// ******************************************************************************
+module.exports = class ReportingProtocol {
+  constructor () {
+    this.handlers = {}
+  }
+
+  async initialize () {
+    const [ records ] = await DB.list()
+    const handlersDir = path.join(__dirname, '../reportingProtocols')
+    records.forEach(x => {
+      let Handler = require(path.join(handlersDir, x.protocolHandler))
+      this.handlers[x.id] = new Handler({ reportingProtocolId: x.id })
+    })
+  }
+
+  load (id) {
+    return DB.load({ id })
+  }
+
+  async list (query = {}, opts) {
+    return DB.list(renameQueryKeys(query), opts)
+  }
+
+  create (name, protocolHandler) {
+    return DB.create({ name, protocolHandler })
+  }
+
+  update ({ id, ...data }) {
+    if (!id) throw httpError(400, 'No existing ReportingProtocol ID')
+    return DB.update({ id }, data)
+  }
+
+  remove (id) {
+    return DB.remove({ id })
+  }
+
+  getHandler (id) {
+    return this.handlers[id]
+  }
+}

--- a/rest/models/IUser.js
+++ b/rest/models/IUser.js
@@ -1,195 +1,14 @@
 const appLogger = require('../lib/appLogger.js')
 const config = require('../config')
-const { prisma, formatInputData, formatRelationshipsIn, loadRecord } = require('../lib/prisma')
+const { prisma, formatInputData } = require('../lib/prisma')
 const crypto = require('../lib/crypto.js')
 const uuidgen = require('uuid')
 const httpError = require('http-errors')
-const { onFail } = require('../lib/utils')
+const { onFail, renameKeys } = require('../lib/utils')
 const R = require('ramda')
 const Joi = require('@hapi/joi')
-
-module.exports = class User {
-  constructor (modelAPI) {
-    this.modelAPI = modelAPI
-  }
-
-  async init () {
-    // Expire records every 24 hours.
-    // (24 hours * 60 minutes * 60 seconds * 1000 milliseconds)
-    setInterval(this.expireEmailVerify.bind(this), 24 * 60 * 60 * 1000)
-    // Run expiration code at startup as well.
-    this.expireEmailVerify()
-  }
-
-  // We run this "periodically" to delete old emailVerify records.  We user
-  // the handler code above with a "reject" type and an "expired" source so
-  // the handling and reporting code is in one place.
-  async expireEmailVerify () {
-    appLogger.log('Running expiration of email verify records')
-    // 14 day limit on email changes.
-    var timedOut = new Date()
-    // Move now back 14 days.
-    timedOut.setDate(timedOut.getDate() - 14)
-    const where = { changeRequested_lt: timedOut.toISOString() }
-    const records = await prisma.emailVerifications({ where })
-    appLogger.log(records.length + ' email verify records to be expired')
-    return Promise.all(
-      records.map(x => this.handleEmailVerifyResponse(x.uuid, 'reject', 'expired verification request'))
-    )
-  }
-
-  async create (data) {
-    // Check payload against Joi schema
-    let { error } = Joi.validate(data, userCreateSchema)
-    if (error) throw httpError(400, error.message)
-    // Verify password passes company password policy
-    await this.modelAPI.passwordPolicies.validatePassword(data.companyId, data.password)
-    let user
-    try {
-      data.passwordHash = await crypto.hashPassword(data.password)
-      delete data.password
-      user = await prisma.createUser(formatInputData(data)).$fragment(fragments.profile)
-    }
-    catch (err) {
-      throw httpError(400, err.message)
-    }
-    if (user.email) {
-      try {
-        await emailVerify(user.id, user.username, user.email, null, config.get('base_url'))
-      }
-      catch (err) {
-        // Log error, but resolve anyway.
-        appLogger.log('Error starting email verification:' + err)
-      }
-    }
-    return dropInternalProps(user)
-  }
-
-  load (id, fragment = 'basic') {
-    return loadUser({ id }, fragment)
-  }
-
-  loadByUsername (username, fragment = 'basic') {
-    return loadUser({ username }, fragment)
-  }
-
-  async update ({ id, ...data }) {
-    // MUST have at least an ID field in the passed update record.
-    if (!id) throw httpError(400, 'No existing user ID')
-
-    let originalUser = await this.load(id)
-    data = formatInputData(data)
-
-    if (data.password) {
-      const company = data.company || originalUser.company
-      // Validate the password.
-      await this.modelAPI.passwordPolicies.validatePassword(company.id, data.password)
-      data.passwordHash = await crypto.hashPassword(data.password)
-      delete data.password
-    }
-
-    if (data.role === 'ADMIN' && !(data.email || originalUser.email)) {
-      throw httpError(400, 'Invalid change to ADMIN without an email')
-    }
-
-    function setEmailProps ({ email, ...data }) {
-      if (email === originalUser.email) return data
-      const result = { ...data, emailVerified: false }
-      if (originalUser.emailVerified) {
-        result.lastVerifiedEmail = originalUser.email
-      }
-      return result
-    }
-
-    if (data.email) data = setEmailProps(data)
-
-    let user = await onFail(400, () => prisma.updateUser({ data, where: { id } }).$fragment(fragments.internal))
-
-    if (data.email) {
-      try {
-        await emailVerify(
-          user.id,
-          user.username,
-          user.email,
-          user.lastVerifiedEmail,
-          config.get('base_url')
-        )
-      }
-      catch (err) {
-        appLogger.log('Error starting email verification:' + err)
-      }
-    }
-
-    return dropInternalProps(user)
-  }
-
-  async list ({ limit, offset, ...where } = {}) {
-    where = formatRelationshipsIn(where)
-    if (where.search) {
-      where.username_contains = where.search
-      delete where.search
-    }
-    const query = { where }
-    if (limit) query.first = limit
-    if (offset) query.skip = offset
-    const [records, totalCount] = await Promise.all([
-      prisma.users(query).$fragment(fragments.basic),
-      prisma.usersConnection({ where }).aggregate().count()
-    ])
-    return { totalCount, records }
-  }
-
-  remove (id) {
-    return onFail(400, () => prisma.deleteUser({ id }))
-  }
-
-  async authorizeUser (username, password) {
-    try {
-      const user = await loadUser({ username }, 'internal')
-      const matches = await crypto.verifyPassword(password, user.passwordHash)
-      if (!matches) throw new Error(`authorizeUser: passwords don't match username "${username}`)
-      return dropInternalProps(user)
-    }
-    catch (err) {
-      // don't specify whether or not username is valid
-      throw new httpError.Unauthorized()
-    }
-  }
-
-  async handleEmailVerifyResponse (uuid, type, source) {
-    const ev = await retrieveEmailVerification(uuid)
-    const user = await loadUser(ev.user)
-    let userUpdate = { id: user.id }
-    if (type === 'accept') {
-      userUpdate.emailVerified = true
-    }
-    else {
-      this.modelAPI.emails.notifyAdminsAboutReject(user, source)
-      Object.assign(userUpdate, {
-        email: user.lastVerifiedEmail,
-        lastVerifiedEmail: '',
-        emailVerified: true
-      })
-    }
-    try {
-      await this.update(userUpdate)
-      await deleteEmailVerification(uuid)
-    }
-    catch (err) {
-      appLogger.log('Update for EmailVerify failed. UUID = ' + uuid +
-                                           ', type = ' + type +
-                                           ', source = ' + source +
-                                          ': ' + err)
-      throw httpError.InternalServerError()
-    }
-  }
-
-  async getCompanyAdmins (companyId) {
-    const where = { company: { id: companyId } }
-    const users = await prisma.users({ where }).$fragment(fragments.userEmail)
-    return users.map(x => x.email).filter(R.identity)
-  }
-}
+const { redisClient } = require('../lib/redis')
+const CacheFirstStrategy = require('../../lib/prisma-cache/src/cache-first-strategy')
 
 //* *****************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -242,6 +61,19 @@ const fragments = {
   }`
 }
 
+// ******************************************************************************
+// Database Client
+// ******************************************************************************
+const DB = new CacheFirstStrategy({
+  name: 'user',
+  pluralName: 'users',
+  fragments,
+  defaultFragmentKey: 'basic',
+  prisma,
+  redis: redisClient,
+  log: appLogger.log.bind(appLogger)
+})
+
 // *********************************************************************
 // Helpers
 // *********************************************************************
@@ -253,7 +85,7 @@ const userCreateSchema = Joi.object().keys({
   email: Joi.string().email({ minDomainSegments: 2 }).when('role', { is: 'ADMIN', then: Joi.required(), otherwise: Joi.optional() })
 })
 
-const loadUser = loadRecord('user', fragments, 'basic')
+const renameQueryKeys = renameKeys({ search: 'username_contains' })
 
 async function retrieveEmailVerification (uuid) {
   const ev = await onFail(400, () => prisma.emailVerification({ uuid }).$fragment(fragments.emailVerification))
@@ -305,3 +137,176 @@ async function emailVerify (userId, username, newemail, oldemail, urlRoot) {
 }
 
 const dropInternalProps = R.omit(['passwordHash', 'emailVerified', 'lastVerifiedEmail'])
+
+// *********************************************************************
+// Model
+// *********************************************************************
+module.exports = class User {
+  constructor (modelAPI) {
+    this.modelAPI = modelAPI
+  }
+
+  async init () {
+    // Expire records every 24 hours.
+    // (24 hours * 60 minutes * 60 seconds * 1000 milliseconds)
+    setInterval(this.expireEmailVerify.bind(this), 24 * 60 * 60 * 1000)
+    // Run expiration code at startup as well.
+    this.expireEmailVerify()
+  }
+
+  load (id, fragment = 'basic') {
+    return DB.load({ id }, { fragment })
+  }
+
+  loadByUsername (username, fragment = 'basic') {
+    return DB.load({ username }, { fragment })
+  }
+
+  async list (query = {}, opts) {
+    return DB.list(renameQueryKeys(query), opts)
+  }
+
+  async create (data) {
+    // Check payload against Joi schema
+    let { error } = Joi.validate(data, userCreateSchema)
+    if (error) throw httpError(400, error.message)
+    // Verify password passes company password policy
+    await this.modelAPI.passwordPolicies.validatePassword(data.companyId, data.password)
+    let user
+    try {
+      data.passwordHash = await crypto.hashPassword(data.password)
+      delete data.password
+      user = await DB.create(data, { fragment: 'profile' })
+    }
+    catch (err) {
+      throw httpError(400, err.message)
+    }
+    if (user.email) {
+      try {
+        await emailVerify(user.id, user.username, user.email, null, config.get('base_url'))
+      }
+      catch (err) {
+        // Log error, but resolve anyway.
+        appLogger.log('Error starting email verification:' + err)
+      }
+    }
+    return dropInternalProps(user)
+  }
+
+  async update ({ id, ...data }) {
+    // MUST have at least an ID field in the passed update record.
+    if (!id) throw httpError(400, 'No existing user ID')
+
+    let originalUser = await this.load(id)
+
+    if (data.password) {
+      const companyId = data.companyId || data.company ? data.company.id : originalUser.company.id
+      // Validate the password.
+      await this.modelAPI.passwordPolicies.validatePassword(companyId, data.password)
+      data.passwordHash = await crypto.hashPassword(data.password)
+      delete data.password
+    }
+
+    if (data.role === 'ADMIN' && !(data.email || originalUser.email)) {
+      throw httpError(400, 'Invalid change to ADMIN without an email')
+    }
+
+    function setEmailProps ({ email, ...data }) {
+      if (email === originalUser.email) return data
+      const result = { ...data, emailVerified: false }
+      if (originalUser.emailVerified) {
+        result.lastVerifiedEmail = originalUser.email
+      }
+      return result
+    }
+
+    if (data.email) data = setEmailProps(data)
+
+    let user = await DB.update({ id }, data, { fragment: 'internal' })
+
+    if (data.email) {
+      try {
+        await emailVerify(
+          user.id,
+          user.username,
+          user.email,
+          user.lastVerifiedEmail,
+          config.get('base_url')
+        )
+      }
+      catch (err) {
+        appLogger.log('Error starting email verification:' + err)
+      }
+    }
+
+    return dropInternalProps(user)
+  }
+
+  remove (id) {
+    return DB.remove({ id })
+  }
+
+  // We run this "periodically" to delete old emailVerify records.  We user
+  // the handler code above with a "reject" type and an "expired" source so
+  // the handling and reporting code is in one place.
+  async expireEmailVerify () {
+    appLogger.log('Running expiration of email verify records')
+    // 14 day limit on email changes.
+    var timedOut = new Date()
+    // Move now back 14 days.
+    timedOut.setDate(timedOut.getDate() - 14)
+    const where = { changeRequested_lt: timedOut.toISOString() }
+    const records = await prisma.emailVerifications({ where })
+    appLogger.log(records.length + ' email verify records to be expired')
+    return Promise.all(
+      records.map(x => this.handleEmailVerifyResponse(x.uuid, 'reject', 'expired verification request'))
+    )
+  }
+
+  async authorizeUser (username, password) {
+    try {
+      const user = await this.loadByUsername(username, 'internal')
+      const matches = await crypto.verifyPassword(password, user.passwordHash)
+      if (!matches) throw new Error(`authorizeUser: passwords don't match username "${username}`)
+      return dropInternalProps(user)
+    }
+    catch (err) {
+      // don't specify whether or not username is valid
+      throw new httpError.Unauthorized()
+    }
+  }
+
+  async handleEmailVerifyResponse (uuid, type, source) {
+    const ev = await retrieveEmailVerification(uuid)
+    const user = await this.load(ev.user.id)
+    let userUpdate = { id: user.id }
+    if (type === 'accept') {
+      userUpdate.emailVerified = true
+    }
+    else {
+      this.modelAPI.emails.notifyAdminsAboutReject(user, source)
+      Object.assign(userUpdate, {
+        email: user.lastVerifiedEmail,
+        lastVerifiedEmail: '',
+        emailVerified: true
+      })
+    }
+    try {
+      await this.update(userUpdate)
+      await deleteEmailVerification(uuid)
+    }
+    catch (err) {
+      appLogger.log('Update for EmailVerify failed. UUID = ' + uuid +
+                                           ', type = ' + type +
+                                           ', source = ' + source +
+                                          ': ' + err)
+      throw httpError.InternalServerError()
+    }
+  }
+
+  async getCompanyAdmins (companyId) {
+    const where = { company: { id: companyId } }
+    const users = await prisma.users({ where }).$fragment(fragments.userEmail)
+    return users.map(x => x.email).filter(R.identity)
+  }
+}

--- a/rest/networkProtocols/handlers/LoraOpenSource/LoraOpenSource.js
+++ b/rest/networkProtocols/handlers/LoraOpenSource/LoraOpenSource.js
@@ -462,7 +462,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
     const [localApps] = await this.modelAPI.applications.list({ search: remoteApp.name })
     let localApp = localApps[0]
     const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
-    const { records: reportingProtos } = await this.modelAPI.reportingProtocols.list()
+    const [ reportingProtos ] = await this.modelAPI.reportingProtocols.list()
     if (!localApp) {
       let localAppData = {
         ...R.pick(['name', 'description'], remoteApp),

--- a/rest/networkProtocols/handlers/LoraOpenSource/LoraOpenSource.js
+++ b/rest/networkProtocols/handlers/LoraOpenSource/LoraOpenSource.js
@@ -269,7 +269,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
   }
 
   async pushApplications (network, modelAPI, dataAPI) {
-    let { records: apps } = await this.modelAPI.applications.list()
+    let [apps] = await this.modelAPI.applications.list()
     await Promise.all(apps.map(x => this.pushApplication(network, x, dataAPI, false)))
   }
 
@@ -295,7 +295,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
   }
 
   async pushDeviceProfiles (network, modelAPI, dataAPI) {
-    let { records: dps } = await this.modelAPI.deviceProfiles.list()
+    let [ dps ] = await this.modelAPI.deviceProfiles.list()
     await Promise.all(dps.map(x => this.pushDeviceProfile(network, x, dataAPI, false)))
   }
 
@@ -320,8 +320,8 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
   }
 
   async pushDevices (network, modelAPI, dataAPI) {
-    let { records } = await this.modelAPI.devices.list()
-    await Promise.all(records.map(x => this.pushDevice(network, x, dataAPI, false)))
+    let [ devices ] = await this.modelAPI.devices.list()
+    await Promise.all(devices.map(x => this.pushDevice(network, x, dataAPI, false)))
   }
 
   async pushDevice (network, device, dataAPI, update = true) {
@@ -357,7 +357,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
   }
 
   async setupOrganization (network, modelAPI, dataAPI) {
-    const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+    const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
     let company = cos[0]
     let companyNtl = await dataAPI.getCompanyNetworkType(company.id, network.networkType.id)
     let loraNetworkSettings = { network: network.id }
@@ -408,13 +408,13 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
   }
 
   async addRemoteDeviceProfile (network, remoteDevProfileId) {
-    const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+    const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
     let company = cos[0]
     const remoteDeviceProfile = await this.client.loadDeviceProfile(network, remoteDevProfileId)
     appLogger.log('Adding ' + remoteDeviceProfile.name)
-    const { totalCount, records } = await this.modelAPI.deviceProfiles.list({ search: remoteDeviceProfile.name })
-    if (totalCount > 0) {
-      let localDp = records[0]
+    const [ dps ] = await this.modelAPI.deviceProfiles.list({ search: remoteDeviceProfile.name, limit: 1 })
+    if (dps.length) {
+      let localDp = dps[0]
       appLogger.log(localDp.name + ' already exists')
       await this.modelAPI.protocolData.upsert(network, makeDeviceProfileDataKey(localDp.id, 'dpNwkId'), remoteDeviceProfile.id)
       return {
@@ -459,9 +459,9 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
       if (err.statusCode !== 404) throw err
     }
     // Check for local app with the same name
-    const { records: localApps } = await this.modelAPI.applications.list({ search: remoteApp.name })
+    const [localApps] = await this.modelAPI.applications.list({ search: remoteApp.name })
     let localApp = localApps[0]
-    const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+    const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
     const { records: reportingProtos } = await this.modelAPI.reportingProtocols.list()
     if (!localApp) {
       let localAppData = {
@@ -473,7 +473,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
       localApp = await this.modelAPI.applications.create(localAppData)
       appLogger.log('Created ' + localApp.name)
     }
-    const { records: appNtls } = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: localApp.id })
+    const [ appNtls ] = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId: localApp.id })
     let appNtl = appNtls[0]
     if (appNtl) {
       appLogger.log(localApp.name + ' link already exists')
@@ -520,10 +520,10 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
       appLogger.log('Device does not have keys or activation', 'info')
     }
 
-    let localDevResult = await this.modelAPI.devices.list({ search: remoteDevice.name })
+    let [ localDevices ] = await this.modelAPI.devices.list({ search: remoteDevice.name }, { limit: 1 })
     let localDevice
-    if (localDevResult.totalCount > 0) {
-      localDevice = localDevResult.records[0]
+    if (localDevices.length) {
+      localDevice = localDevices[0]
       appLogger.log(localDevice.name + ' already exists')
     }
     else {
@@ -531,12 +531,12 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
       localDevice = await this.modelAPI.devices.create(remoteDevice.name, remoteDevice.description, localAppId)
       appLogger.log('Created ' + localDevice.name)
     }
-    let localDevNtlResult = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: localDevice.id })
-    if (localDevNtlResult.totalCount > 0) {
+    let [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId: localDevice.id, limit: 1 })
+    if (devNtls.length) {
       appLogger.log(localDevice.name + ' link already exists')
     }
     else {
-      const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+      const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
       let company = cos[0]
       appLogger.log('creating Network Link for ' + localDevice.name)
       let networkSettings = this.buildDeviceNetworkSettings(remoteDevice)
@@ -661,7 +661,7 @@ module.exports = class LoraOpenSource extends NetworkProtocol {
     appLogger.log('Adding DP ' + deviceProfileId)
     // Get the deviceProfile data.
     const deviceProfile = await dataAPI.getDeviceProfileById(deviceProfileId)
-    const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+    const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
     let company = cos[0]
     appLogger.log(company)
     let orgId = await this.modelAPI.protocolData.loadValue(network, makeCompanyDataKey(company.id, 'coNwkId'))

--- a/rest/networkProtocols/handlers/Loriot/Loriot.js
+++ b/rest/networkProtocols/handlers/Loriot/Loriot.js
@@ -47,7 +47,7 @@ module.exports = class Loriot extends NetworkProtocol {
     const [ integration ] = remoteApp.outputs.filter(x => x.output === 'httppush')
     const [localApps] = await modelAPI.applications.list({ search: remoteApp.name })
     const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
-    const { records: reportingProtos } = await modelAPI.reportingProtocols.list()
+    const [ reportingProtos ] = await modelAPI.reportingProtocols.list()
     let localApp = localApps[0]
     if (!localApp) {
       let localAppData = {

--- a/rest/networkProtocols/handlers/TheThingsNetwork/v2/index.js
+++ b/rest/networkProtocols/handlers/TheThingsNetwork/v2/index.js
@@ -29,10 +29,10 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
   async subscribeToDataForEnabledApps () {
     const nwkType = await this.modelAPI.networkTypes.loadByName('LoRa')
     const antlQuery = { networkType: { id: nwkType.id } }
-    const { records: antls } = await this.modelAPI.applicationNetworkTypeLinks.list(antlQuery)
+    const [ antls ] = await this.modelAPI.applicationNetworkTypeLinks.list(antlQuery)
     let appIds = antls.map(R.path(['application', 'id']))
     const networkQuery = { networkProtocol: { id: this.networkProtocolId } }
-    const { records: networks } = await this.modelAPI.networks.list(networkQuery)
+    const [ networks ] = await this.modelAPI.networks.list(networkQuery)
     try {
       const promises = R.flatten(networks.map(nwk => appIds.map(id => this.startApplication(nwk, id))))
       await Promise.all(promises)
@@ -125,9 +125,9 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
         if (err.statusCode !== 404) throw err
       }
       let normalizedApplication = this.normalizeApplicationData(handlerApp, accountServerApp, network)
-      const { records: localApps } = await modelAPI.applications.list({ search: accountServerApp.name })
+      const [localApps] = await modelAPI.applications.list({ search: accountServerApp.name })
       let localApp = localApps[0]
-      const { records: cos } = await modelAPI.companies.list()
+      const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
       const { records: reportingProtos } = await modelAPI.reportingProtocols.list()
       if (!localApp) {
         const localAppData = {
@@ -140,7 +140,7 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
         appLogger.log('Created ' + localApp.name)
       }
 
-      let { records: appNtls } = await modelAPI.applicationNetworkTypeLinks.list({ applicationId: localApp.id })
+      let [ appNtls ] = await modelAPI.applicationNetworkTypeLinks.list({ applicationId: localApp.id })
       let appNtl = appNtls[0]
       if (!appNtl) {
         appNtl = await modelAPI.applicationNetworkTypeLinks.create(
@@ -192,13 +192,13 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
   }
 
   async addRemoteDevice (remoteDevice, network, localAppId, dpMap, modelAPI, dataAPI) {
+    let existingDevice
     appLogger.log('Adding ' + remoteDevice.deveui)
     appLogger.log(remoteDevice)
-    let existingDevice = await modelAPI.devices.list({ search: remoteDevice.lorawan_device.dev_eui })
+    let [ existingDevices ] = await modelAPI.devices.list({ search: remoteDevice.lorawan_device.dev_eui, limit: 1 })
 
-    appLogger.log(existingDevice)
-    if (existingDevice.totalCount > 0) {
-      existingDevice = existingDevice.records[0]
+    if (existingDevices.length) {
+      existingDevice = existingDevices[0]
       appLogger.log(existingDevice.name + ' already exists')
     }
     else {
@@ -207,10 +207,10 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
       appLogger.log('Created ' + existingDevice.name)
     }
 
-    let existingDeviceNTL = await modelAPI.deviceNetworkTypeLinks.list({ deviceId: existingDevice.id })
+    let [ devNtls ] = await modelAPI.deviceNetworkTypeLinks.list({ deviceId: existingDevice.id, limit: 1 })
     let existingApplicationNTL = await modelAPI.applicationNetworkTypeLinks.load(localAppId)
 
-    if (existingDeviceNTL.totalCount > 0) {
+    if (devNtls.length) {
       appLogger.log(existingDevice.name + ' link already exists')
       return { localDevice: existingDevice.id, remoteDevice: remoteDevice.dev_id }
     }
@@ -235,7 +235,7 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
   async addRemoteDeviceProfile (remoteDevice, application, network) {
     let networkSpecificDeviceProfileInformation = this.normalizeDeviceProfileData(remoteDevice, application)
     appLogger.log(networkSpecificDeviceProfileInformation, 'error')
-    const { records: cos } = await this.modelAPI.companies.list({ limit: 1 })
+    const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
     let company = cos[0]
     try {
       const existingDeviceProfile = await this.modelAPI.deviceProfiles.create(
@@ -280,9 +280,9 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
 
   async pushApplications (network, dataAPI, modelAPI) {
     try {
-      let existingApplications = await modelAPI.applications.list()
+      let [existingApplications] = await modelAPI.applications.list()
       appLogger.log(existingApplications, 'info')
-      const pushedResources = await Promise.all(existingApplications.records.map(record => {
+      const pushedResources = await Promise.all(existingApplications.map(record => {
         return this.pushApplication(network, record, dataAPI, modelAPI)
       }))
       appLogger.log('Success Pushing Applications', 'info')
@@ -324,8 +324,8 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
 
   async pushDevices (network, dataAPI, modelAPI) {
     try {
-      let existingDevices = await modelAPI.devices.list()
-      const pushedResources = await Promise.all(existingDevices.records.map(record => {
+      let [ existingDevices ] = await modelAPI.devices.list()
+      const pushedResources = await Promise.all(existingDevices.map(record => {
         return this.pushDevice(network, record, dataAPI)
       }))
       appLogger.log(pushedResources)

--- a/rest/networkProtocols/handlers/TheThingsNetwork/v2/index.js
+++ b/rest/networkProtocols/handlers/TheThingsNetwork/v2/index.js
@@ -128,7 +128,7 @@ module.exports = class TheThingsNetworkV2 extends NetworkProtocol {
       const [localApps] = await modelAPI.applications.list({ search: accountServerApp.name })
       let localApp = localApps[0]
       const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
-      const { records: reportingProtos } = await modelAPI.reportingProtocols.list()
+      const [ reportingProtos ] = await modelAPI.reportingProtocols.list()
       if (!localApp) {
         const localAppData = {
           ...R.pick(['name', 'description'], normalizedApplication),

--- a/rest/networkProtocols/networkProtocolDataAccess.js
+++ b/rest/networkProtocols/networkProtocolDataAccess.js
@@ -84,7 +84,7 @@ module.exports = class NetworkProtocolDataAccess {
   }
   async getCompanyNetworkType (companyId, networkTypeId) {
     const request = async () => {
-      const { records } = await this.modelAPI.companyNetworkTypeLinks.list({ companyId, networkTypeId })
+      const [ records ] = await this.modelAPI.companyNetworkTypeLinks.list({ companyId, networkTypeId })
       return records[0]
     }
     return this.cacheFirst(
@@ -95,8 +95,8 @@ module.exports = class NetworkProtocolDataAccess {
   }
   async getApplicationNetworkType (applicationId, networkTypeId) {
     const request = async () => {
-      const { records } = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId, networkTypeId })
-      return records[0]
+      const [ apps ] = await this.modelAPI.applicationNetworkTypeLinks.list({ applicationId, networkTypeId })
+      return apps[0]
     }
     return this.cacheFirst(
       ['applicationNetworkTypeLinks', `${applicationId}:${networkTypeId}`],
@@ -106,8 +106,8 @@ module.exports = class NetworkProtocolDataAccess {
   }
   async getDeviceNetworkType (deviceId, networkTypeId) {
     const request = async () => {
-      const { records } = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId, networkTypeId })
-      return records[0]
+      const [ devNtls ] = await this.modelAPI.deviceNetworkTypeLinks.list({ deviceId, networkTypeId, limit: 1 })
+      return devNtls[0]
     }
     return this.cacheFirst(
       ['applicationNetworkTypeLinks', `${deviceId}:${networkTypeId}`],
@@ -117,7 +117,7 @@ module.exports = class NetworkProtocolDataAccess {
   }
   async getDevicesForDeviceProfile (deviceProfileId) {
     const request = async () => {
-      let devs = await this.modelAPI.devices.list({ 'deviceProfileId': deviceProfileId })
+      let [devs] = await this.modelAPI.devices.list({ 'deviceProfileId': deviceProfileId })
       // Put devices in cache (cache is disabled)
       // devs.forEach(x => R.assocPath(['devices', `${x.id}`], x, this.cache))
       return devs.map(x => x.id)

--- a/rest/networkProtocols/networkTypeApi.js
+++ b/rest/networkProtocols/networkTypeApi.js
@@ -56,11 +56,11 @@ NetworkTypeApi.prototype.forAllNetworksOfType = function forAllNetworksOfType (o
     let networkType = await this.modelAPI.networkTypes.load(networkTypeId)
     npda.initLog(networkType, null)
 
-    var networks
+    var networks = []
     try {
       // Get the networks we'll be operating on that support the
       // networkType.
-      networks = await this.modelAPI.networks.list({ 'networkTypeId': networkTypeId })
+      [networks] = await this.modelAPI.networks.list({ 'networkTypeId': networkTypeId })
     }
     catch (err) {
       appLogger.log('Error retrieving networks for type ID ' + networkTypeId)
@@ -69,14 +69,14 @@ NetworkTypeApi.prototype.forAllNetworksOfType = function forAllNetworksOfType (o
       return
     }
 
-    if (networks.records.length === 0) {
+    if (networks.length === 0) {
       // Just resolve.
       resolve(npda.getLogs())
     }
 
-    const done = tracker(networks.records.length, npda, resolve)
+    const done = tracker(networks.length, npda, resolve)
 
-    networks.records.forEach(network => {
+    networks.forEach(network => {
       // Initialize the logging for this network.
       npda.initLog(networkType, network)
       operationFunction(npda, network).then(
@@ -405,7 +405,7 @@ NetworkTypeApi.prototype.deleteDevice = function (networkTypeId, deviceId) {
 NetworkTypeApi.prototype.passDataToDevice = async function (devNTL, appId, deviceId, data) {
   const ipNwkType = await this.modelAPI.networkTypes.loadByName('IP')
   if (ipNwkType && ipNwkType.id === devNTL.networkType.id) {
-    const { records: nwkProtos } = await this.modelAPI.networkProtocols.list({ name: 'IP' })
+    const [ nwkProtos ] = await this.modelAPI.networkProtocols.list({ name: 'IP' })
     const handler = await this.modelAPI.networkProtocols.getHandler(nwkProtos[0].id)
     return handler.passDataToDevice(devNTL, data)
   }

--- a/rest/restApplicationNetworkTypeLinks.js
+++ b/rest/restApplicationNetworkTypeLinks.js
@@ -238,7 +238,7 @@ exports.initialize = function (app, server) {
       else {
         // Do the update.
         // TODO: Get rid of companies.  For now it is always cablelabs HACK
-        const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
+        const [ cos ] = await modelAPI.companies.list({ limit: 1 })
         let company = cos[0]
         modelAPI.applicationNetworkTypeLinks.update(data, { companyId: company.id }).then(function (rec) {
           restServer.respondJson(res, 200, { remoteAccessLogs: rec.remoteAccessLogs })

--- a/rest/restApplicationNetworkTypeLinks.js
+++ b/rest/restApplicationNetworkTypeLinks.js
@@ -71,8 +71,8 @@ exports.initialize = function (app, server) {
         options.offset = offsetInt
       }
     }
-    modelAPI.applicationNetworkTypeLinks.list(options).then(function (networkTypes) {
-      const responseBody = { ...networkTypes, records: networkTypes.records.map(formatRelationshipsOut) }
+    modelAPI.applicationNetworkTypeLinks.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
+      const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
       restServer.respondJson(res, null, responseBody)
     })
       .catch(function (err) {
@@ -238,7 +238,7 @@ exports.initialize = function (app, server) {
       else {
         // Do the update.
         // TODO: Get rid of companies.  For now it is always cablelabs HACK
-        const { records: cos } = await modelAPI.companies.list({ limit: 1 })
+        const [ cos ] = await this.modelAPI.companies.list({ limit: 1 })
         let company = cos[0]
         modelAPI.applicationNetworkTypeLinks.update(data, { companyId: company.id }).then(function (rec) {
           restServer.respondJson(res, 200, { remoteAccessLogs: rec.remoteAccessLogs })

--- a/rest/restApplications.js
+++ b/rest/restApplications.js
@@ -101,8 +101,8 @@ exports.initialize = function (app, server) {
     if (req.query.networkProtocolId) {
       options.networkProtocolId = req.query.networkProtocolId
     }
-    modelAPI.applications.list(options).then(function (cos) {
-      const responseBody = { ...cos, records: cos.records.map(formatRelationshipsOut) }
+    modelAPI.applications.list(options, { includeTotal: true }).then(function ([recs, totalCount]) {
+      const responseBody = { totalCount, records: recs.map(formatRelationshipsOut) }
       restServer.respondJson(res, null, responseBody)
     })
       .catch(function (err) {

--- a/rest/restCompanies.js
+++ b/rest/restCompanies.js
@@ -69,8 +69,8 @@ exports.initialize = function (app, server) {
       if (req.query.search) {
         options.search = req.query.search
       }
-      const result = await modelAPI.companies.list(options)
-      restServer.respond(res, 200, result, true)
+      const [ records, totalCount ] = await modelAPI.companies.list(options, { includeTotal: true })
+      restServer.respond(res, 200, { records, totalCount }, true)
     }
     catch (err) {
       appLogger.log('Error getting companies: ' + err)

--- a/rest/restCompanyNetworkTypeLinks.js
+++ b/rest/restCompanyNetworkTypeLinks.js
@@ -69,8 +69,8 @@ exports.initialize = function (app, server) {
         options.offset = offsetInt
       }
     }
-    modelAPI.companyNetworkTypeLinks.list(options).then(function (networkTypes) {
-      const responseBody = { ...networkTypes, records: networkTypes.records.map(formatRelationshipsOut) }
+    modelAPI.companyNetworkTypeLinks.list(options).then(function ([ records, totalCount ]) {
+      const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
       restServer.respondJson(res, null, responseBody)
     })
       .catch(function (err) {

--- a/rest/restDeviceNetworkTypeLinks.js
+++ b/rest/restDeviceNetworkTypeLinks.js
@@ -69,8 +69,8 @@ exports.initialize = function (app, server) {
         options.offset = offsetInt
       }
     }
-    modelAPI.deviceNetworkTypeLinks.list(options).then(function (networks) {
-      const responseBody = { ...networks, records: networks.records.map(formatRelationshipsOut) }
+    modelAPI.deviceNetworkTypeLinks.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
+      const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
       restServer.respondJson(res, null, responseBody)
     })
       .catch(function (err) {

--- a/rest/restDeviceProfiles.js
+++ b/rest/restDeviceProfiles.js
@@ -94,8 +94,8 @@ exports.initialize = function (app, server) {
       options.networkTypeId = req.query.networkTypeId
     }
 
-    modelAPI.deviceProfiles.list(options).then(function (dps) {
-      const responseBody = { ...dps, records: dps.records.map(formatRelationshipsOut) }
+    modelAPI.deviceProfiles.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
+      const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
       restServer.respondJson(res, null, responseBody)
     })
       .catch(function (err) {

--- a/rest/restDevices.js
+++ b/rest/restDevices.js
@@ -88,8 +88,8 @@ exports.initialize = function (app, server) {
       if (req.query.applicationId) {
         options.applicationId = req.query.applicationId
       }
-      modelAPI.devices.list(options).then(function (cos) {
-        const responseBody = { ...cos, records: cos.records.map(formatRelationshipsOut) }
+      modelAPI.devices.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
+        const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
         restServer.respondJson(res, null, responseBody)
       })
         .catch(function (err) {

--- a/rest/restNetworkProtocols.js
+++ b/rest/restNetworkProtocols.js
@@ -71,9 +71,9 @@ exports.initialize = function (app, server) {
       if (req.query.networkProtocolVersion) {
         options.networkProtocolVersion = req.query.networkProtocolVersion
       }
-      modelAPI.networkProtocols.list(options).then(function (nps) {
+      modelAPI.networkProtocols.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
         // restServer.respondJson(res, null, nps)
-        const responseBody = { ...nps, records: nps.records.map(formatRelationshipsOut) }
+        const responseBody = { totalCount, records: records.map(formatRelationshipsOut) }
         restServer.respond(res, 200, responseBody)
       })
         .catch(function (err) {
@@ -103,14 +103,11 @@ exports.initialize = function (app, server) {
       if (req.query.networkTypeId) {
         options.networkTypeId = req.query.networkTypeId
       }
-      modelAPI.networkProtocols.list(options).then(function (recs) {
-        let nps = {
-          totalCount: recs.totalCount,
-          records: []
-        }
-        let len = recs.records.length
+      modelAPI.networkProtocols.list(options, { includeTotal: true }).then(([ recs, totalCount ]) => {
+        let nps = { totalCount, records: [] }
+        let len = recs.length
         for (let i = 0; i < len; i++) {
-          let rec = recs.records[i]
+          let rec = recs[i]
           let found = false
           let counter = 0
           while (!found && counter < nps.records.length) {
@@ -349,7 +346,7 @@ exports.initialize = function (app, server) {
      */
   app.get('/api/networkProtocolHandlers/', [restServer.isLoggedIn],
     async function (req, res) {
-      const { records } = await modelAPI.networkProtocols.list()
+      const [ records ] = await modelAPI.networkProtocols.list()
       const handlerList = records
         .map(x => x.protocolHandler)
         .map(x => ({ id: x, name: x }))

--- a/rest/restNetworkProviders.js
+++ b/rest/restNetworkProviders.js
@@ -58,8 +58,8 @@ exports.initialize = function (app, server) {
     if (req.query.search) {
       options.search = req.query.search
     }
-    modelAPI.networkProviders.list(options).then(function (nps) {
-      restServer.respondJson(res, null, nps)
+    modelAPI.networkProviders.list(options, { includeTotal: true }).then(([ records, totalCount ]) => {
+      restServer.respondJson(res, null, { records, totalCount })
     })
       .catch(function (err) {
         appLogger.log('Error getting networkProviders: ' + err)

--- a/rest/restNetworkTypes.js
+++ b/rest/restNetworkTypes.js
@@ -41,9 +41,9 @@ exports.initialize = function (app, server) {
      * @apiSuccess {String} object.records.name The name of the Network Type
      * @apiVersion 0.1.0
      */
-  app.get('/api/networkTypes', [restServer.isLoggedIn], function (req, res, next) {
-    modelAPI.networkTypes.list().then(function (nts) {
-      restServer.respondJson(res, null, nts)
+  app.get('/api/networkTypes', [restServer.isLoggedIn], function (req, res) {
+    modelAPI.networkTypes.list({}, { includeTotal: true }).then(([ records, totalCount ]) => {
+      restServer.respondJson(res, null, { records, totalCount })
     })
       .catch(function (err) {
         appLogger.log('Error getting networkTypes: ' + err)

--- a/rest/restNetworks.js
+++ b/rest/restNetworks.js
@@ -89,32 +89,32 @@ exports.initialize = function (app, server) {
     }
     const isAdmin = req.company.type !== 'ADMIN'
     const mapSecurityData = isAdmin ? R.identity : R.pick(['authorized', 'message', 'enabled'])
-    modelAPI.networks.list(options).then(function (networks) {
-      for (let i = 0; i < networks.records.length; ++i) {
-        if (networks.records[i].securityData) {
+    modelAPI.networks.list(options, { includeTotal: true }).then(([ networks, totalCount ]) => {
+      for (let i = 0; i < networks.length; ++i) {
+        if (networks[i].securityData) {
           let temp = {
-            authorized: networks.records[i].securityData.authorized,
-            message: networks.records[i].securityData.message,
-            enabled: networks.records[i].securityData.enabled
+            authorized: networks[i].securityData.authorized,
+            message: networks[i].securityData.message,
+            enabled: networks[i].securityData.enabled
           }
-          appLogger.log(networks.records[i])
-          if (networks.records[i].securityData.clientId) {
-            temp.clientId = networks.records[i].securityData.clientId
-            temp.clientSecret = networks.records[i].securityData.clientSecret
+          appLogger.log(networks[i])
+          if (networks[i].securityData.clientId) {
+            temp.clientId = networks[i].securityData.clientId
+            temp.clientSecret = networks[i].securityData.clientSecret
           }
-          else if (networks.records[i].securityData.apikey) {
-            temp.apikey = networks.records[i].securityData.apikey
+          else if (networks[i].securityData.apikey) {
+            temp.apikey = networks[i].securityData.apikey
           }
-          else if (networks.records[i].securityData.username) {
-            temp.username = networks.records[i].securityData.username
-            temp.password = networks.records[i].securityData.password
+          else if (networks[i].securityData.username) {
+            temp.username = networks[i].securityData.username
+            temp.password = networks[i].securityData.password
           }
-          networks.records[i].securityData = mapSecurityData(temp)
+          networks[i].securityData = mapSecurityData(temp)
         }
       }
       const responseBody = {
-        ...networks,
-        records: networks.records.map(formatRelationshipsOut)
+        totalCount,
+        records: networks.map(formatRelationshipsOut)
       }
       restServer.respond(res, 200, responseBody)
     })
@@ -154,15 +154,12 @@ exports.initialize = function (app, server) {
     }
     const isAdmin = req.company.type !== 'ADMIN'
     const mapSecurityData = isAdmin ? R.identity : R.pick(['authorized', 'message', 'enabled'])
-    modelAPI.networks.list(options).then(function (networks) {
-      modelAPI.networkProtocols.list(options).then(function (recs) {
-        let nps = {
-          totalCount: recs.totalCount,
-          records: []
-        }
-        let len = recs.records.length
+    modelAPI.networks.list(options, { includeTotal: true }).then(([ networks ]) => {
+      modelAPI.networkProtocols.list(options, { includeTotal: true }).then(([ recs, totalCount ]) => {
+        let nps = { totalCount, records: [] }
+        let len = recs.length
         for (let i = 0; i < len; i++) {
-          let rec = recs.records[i]
+          let rec = recs[i]
           let found = false
           let counter = 0
           while (!found && counter < nps.records.length) {
@@ -186,31 +183,31 @@ exports.initialize = function (app, server) {
           }
         }
 
-        for (let i = 0; i < networks.records.length; ++i) {
-          if (networks.records[i].securityData) {
+        for (let i = 0; i < networks.length; ++i) {
+          if (networks[i].securityData) {
             let temp = {
-              authorized: networks.records[i].securityData.authorized,
-              message: networks.records[i].securityData.message,
-              enabled: networks.records[i].securityData.enabled
+              authorized: networks[i].securityData.authorized,
+              message: networks[i].securityData.message,
+              enabled: networks[i].securityData.enabled
             }
-            appLogger.log(networks.records[i])
-            if (networks.records[i].securityData.clientId) {
-              temp.clientId = networks.records[i].securityData.clientId
-              temp.clientSecret = networks.records[i].securityData.clientSecret
+            appLogger.log(networks[i])
+            if (networks[i].securityData.clientId) {
+              temp.clientId = networks[i].securityData.clientId
+              temp.clientSecret = networks[i].securityData.clientSecret
             }
-            else if (networks.records[i].securityData.apikey) {
-              temp.apikey = networks.records[i].securityData.apikey
+            else if (networks[i].securityData.apikey) {
+              temp.apikey = networks[i].securityData.apikey
             }
-            else if (networks.records[i].securityData.username) {
-              temp.username = networks.records[i].securityData.username
-              temp.password = networks.records[i].securityData.password
+            else if (networks[i].securityData.username) {
+              temp.username = networks[i].securityData.username
+              temp.password = networks[i].securityData.password
             }
-            networks.records[i].securityData = mapSecurityData(temp)
+            networks[i].securityData = mapSecurityData(temp)
           }
           // Add network to correct protocol
           for (let npIndex = 0; npIndex < nps.records.length; npIndex++) {
-            if (nps.records[npIndex].versions.includes(networks.records[i].networkProtocol.id)) {
-              nps.records[npIndex].networks.push(formatRelationshipsOut(networks.records[i]))
+            if (nps.records[npIndex].versions.includes(networks[i].networkProtocol.id)) {
+              nps.records[npIndex].networks.push(formatRelationshipsOut(networks[i]))
             }
           }
         }

--- a/rest/restPasswordPolicies.js
+++ b/rest/restPasswordPolicies.js
@@ -47,16 +47,10 @@ exports.initialize = function (app, server) {
         return
       }
 
-      modelAPI.passwordPolicies.list(companyId).then(function (rules) {
+      modelAPI.passwordPolicies.list(companyId).then(function ([ rules ]) {
         for (var i = 0; i < rules.length; ++i) {
-          if (rules[ i ].company) {
-            delete rules[ i ].company
-          }
-          else {
-            // Usually is in the record as "null".
-            delete rules[ i ].company
-            rules[ i ].global = true
-          }
+          if (!rules[i].company) rules[i].global = true
+          delete rules[ i ].company
         }
         restServer.respondJson(res, null, rules)
       })

--- a/rest/restReportingProtocols.js
+++ b/rest/restReportingProtocols.js
@@ -28,8 +28,8 @@ exports.initialize = function (app, server) {
      * @apiVersion 0.1.0
      */
   app.get('/api/reportingProtocols', [restServer.isLoggedIn], function (req, res) {
-    modelAPI.reportingProtocols.list().then(function (rps) {
-      restServer.respondJson(res, null, rps)
+    modelAPI.reportingProtocols.list({}, { includeTotal: true }).then(function ([ records, totalCount ]) {
+      restServer.respondJson(res, null, { records, totalCount })
     })
       .catch(function (err) {
         appLogger.log('Error getting reportingProtocols: ' + err)
@@ -218,7 +218,7 @@ exports.initialize = function (app, server) {
    */
   app.get('/api/reportingProtocolHandlers/', [restServer.isLoggedIn],
     async function (req, res) {
-      const { records } = await modelAPI.reportingProtocols.list()
+      const [ records ] = await modelAPI.reportingProtocols.list()
       const handlerList = records
         .map(x => x.protocolHandler)
         .map(x => ({ id: x, name: x }))

--- a/rest/restUsers.js
+++ b/rest/restUsers.js
@@ -96,9 +96,9 @@ exports.initialize = function (app, server) {
     if (req.query.search) {
       options.search = req.query.search
     }
-    modelAPI.users.list(options).then(function (result) {
-      let records = result.records.map(x => formatRelationshipsOut(x))
-      restServer.respondJson(res, null, { ...result, records })
+    modelAPI.users.list(options, { includeTotal: true }).then(function ([ records, totalCount ]) {
+      records = records.map(x => formatRelationshipsOut(x))
+      restServer.respondJson(res, null, { records, totalCount })
     })
       .catch(function (err) {
         appLogger.log('Error getting users for company ' + req.company.name + ': ' + err)

--- a/test2.0/api/007-restNetworks.js
+++ b/test2.0/api/007-restNetworks.js
@@ -177,6 +177,7 @@ describe('Networks', function () {
           if (err) return done(err)
           res.should.have.status(200)
           var result = JSON.parse(res.text)
+          console.log(result.records)
           result.records.should.be.instanceof(Array)
           result.records.should.have.length(1)
           result.totalCount.should.equal(1)

--- a/test2.0/mock/ModelAPI-mock.js
+++ b/test2.0/mock/ModelAPI-mock.js
@@ -79,7 +79,7 @@ module.exports = {
   },
   applicationNetworkTypeLinks: {
     async list () {
-      return { records: [] }
+      return [[]]
     }
   }
 }

--- a/test2.0/unit/models/IApplication-test.js
+++ b/test2.0/unit/models/IApplication-test.js
@@ -49,9 +49,8 @@ describe('Unit Tests for ' + testName, () => {
   it(testName + ' Empty Retrieval', async () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
-    const actual = await testModule.list()
-    actual.should.have.property('totalCount')
-    actual.should.have.property('records')
+    const actual = await testModule.list({}, { includeTotal: true })
+    actual.should.have.length(2)
   })
   it(testName + ' Create', async () => {
     const cos = await prisma.companies()

--- a/test2.0/unit/models/IDevice-test.js
+++ b/test2.0/unit/models/IDevice-test.js
@@ -7,7 +7,6 @@ const should = chai.should()
 const { prisma } = require('../../../prisma/generated/prisma-client')
 const TestModule = require('../../../rest/models/IDevice')
 const modelAPIMock = require('../../mock/ModelAPI-mock')
-const { redisClient, redisPub, redisSub } = require('../../../rest/lib/redis')
 const testName = 'Device'
 
 function assertDeviceProps (actual) {
@@ -21,11 +20,6 @@ function assertDeviceProps (actual) {
 describe('Unit Tests for ' + testName, () => {
   let deviceId = ''
   before('Setup ENV', async () => {})
-  after('Shutdown', async () => {
-    await redisClient.quit()
-    await redisSub.quit()
-    await redisPub.quit()
-  })
   it(testName + ' Construction', () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
@@ -34,8 +28,7 @@ describe('Unit Tests for ' + testName, () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
     const actual = await testModule.list()
-    actual.should.have.property('totalCount')
-    actual.should.have.property('records')
+    actual.should.have.length(2)
   })
   it(testName + ' Create', async () => {
     const apps = await prisma.applications()

--- a/test2.0/unit/models/IDeviceProfile-test.js
+++ b/test2.0/unit/models/IDeviceProfile-test.js
@@ -29,8 +29,7 @@ describe('Unit Tests for ' + testName, () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
     const actual = await testModule.list()
-    actual.should.have.property('totalCount')
-    actual.should.have.property('records')
+    actual.should.have.length(2)
   })
   it(testName + ' Create', async () => {
     const nwkTypes = await prisma.networkTypes()

--- a/test2.0/unit/models/INetwork-test.js
+++ b/test2.0/unit/models/INetwork-test.js
@@ -46,8 +46,7 @@ describe('Unit Tests for ' + testName, () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
     const actual = await testModule.list()
-    actual.should.have.property('totalCount')
-    actual.should.have.property('records')
+    actual.should.have.length(2)
   })
   it(testName + ' Create', async () => {
     const nwkTypes = await prisma.networkTypes()

--- a/test2.0/unit/models/IUser-test.js
+++ b/test2.0/unit/models/IUser-test.js
@@ -30,8 +30,7 @@ describe('Unit Tests for ' + testName, () => {
     let testModule = new TestModule(modelAPIMock)
     should.exist(testModule)
     const actual = await testModule.list()
-    actual.should.have.property('totalCount')
-    actual.should.have.property('records')
+    actual.should.have.length(2)
   })
   it(testName + ' Create', async () => {
     const cos = await prisma.companies()

--- a/test2.0/unit/setup.js
+++ b/test2.0/unit/setup.js
@@ -1,0 +1,7 @@
+const { redisClient, redisPub, redisSub } = require('../../rest/lib/redis')
+
+after(() => Promise.all([
+  redisClient.quit(),
+  redisPub.quit(),
+  redisSub.quit()
+]))


### PR DESCRIPTION
#### What does this PR do?
- Create an abstraction, used by the models, that automatically manages a Redis cache for single records (not queries).
- Refactor models to use the new abstraction.
- Added a special-use-case caching for the DeviceNetworkTypeLink query on IP device uplinks.
- Limit the "count" aggregation on queries to only REST handlers, or if requested internally.

#### Do you have any concerns with this PR?
No

#### How can the reviewer verify this PR?
Use a Redis data browser while using the demo.

#### Any background context you want to provide?

#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves? #305 
- Does the documentation need an update? Yes, for Redis inclusion
- Does this add new dependencies? object-hash
- Have you added unit or functional tests for this PR? No
