### PR TITLE
Issue 349

### DIFF
--- a/app/api/openapi.yml
+++ b/app/api/openapi.yml
@@ -476,6 +476,33 @@ paths:
           description: ApplicationNetworkTypeLink record was deleted
         "404":
           description: ApplicationNetworkTypeLink not found
+  "/api/application-network-type-links/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushApplicationNetworkTypeLink
+      summary: Push ApplicationNetworkTypeLink
+      description: Push Application to all Networks of this NetworkType
+      parameters:
+        - name: pushDevices
+          in: query
+          description: Whether to also push devices when pushing an
+            ApplicationNetworkTypeLink or a DeviceProfile
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+      security:
+        - bearer_token: []
+      tags:
+        - ApplicationNetworkTypeLink
+      responses:
+        "204":
+          description: ApplicationNetworkTypeLink was pushed
+        "404":
+          description: ApplicationNetworkTypeLink not found
   /api/devices:
     post:
       operationId: createDevice
@@ -834,6 +861,7 @@ paths:
                   required:
                     - deviceId
                     - networkTypeId
+                    - deviceProfileId
         description: DeviceNetworkTypeLink to be created
         required: true
       responses:
@@ -975,6 +1003,22 @@ paths:
       responses:
         "204":
           description: DeviceNetworkTypeLink record was deleted
+        "404":
+          description: DeviceNetworkTypeLink not found
+  "/api/device-network-type-links/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushDeviceNetworkTypeLink
+      summary: Push DeviceNetworkTypeLink
+      description: Push Device to all Networks of this NetworkType
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceNetworkTypeLink
+      responses:
+        "204":
+          description: DeviceNetworkTypeLink was pushed
         "404":
           description: DeviceNetworkTypeLink not found
   /api/device-profiles:
@@ -1140,6 +1184,25 @@ paths:
       responses:
         "204":
           description: DeviceProfile record was deleted
+        "404":
+          description: DeviceProfile not found
+  "/api/device-profiles/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushDeviceProfile
+      summary: Push DeviceProfile
+      description: Push DeviceProfile to all Networks of this NetworkType
+      parameters:
+        - $ref: "#/paths/~1api~1application-network-type-links~1%7Bid%7D~1push/post\
+            /parameters/0"
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceProfile
+      responses:
+        "204":
+          description: DeviceProfile was pushed
         "404":
           description: DeviceProfile not found
   /api/networks:
@@ -1891,6 +1954,17 @@ components:
       required: false
       schema:
         type: string
+    pushDevices:
+      name: pushDevices
+      in: query
+      description: Whether to also push devices when pushing an ApplicationNetworkTypeLink
+        or a DeviceProfile
+      required: false
+      schema:
+        type: string
+        enum:
+          - "true"
+          - "false"
   schemas:
     ResourceCreatedResponse:
       type: object

--- a/app/models/device-network-type-link/index.js
+++ b/app/models/device-network-type-link/index.js
@@ -119,20 +119,6 @@ async function update (ctx, { where, data, origin }) {
   return parseNwkSettings(rec)
 }
 
-async function update (ctx, { where, data, origin }) {
-  if (data.networkSettings) {
-    data = { ...data, networkSettings: prune(data.networkSettings) }
-    validateNwkSettings(data.networkSettings)
-  }
-  const rec = await ctx.db.update({ where, data })
-
-  await ctx.$self.push({
-    deviceProfile: rec,
-    omitNetworks: origin ? [origin.network.id] : []
-  })
-  return rec
-}
-
 async function upsert (ctx, { data, ...args }) {
   try {
     let rec = await ctx.$self.loadByQuery({ where: R.pick(['networkType', 'device'], data) })

--- a/app/models/network-protocol/index.js
+++ b/app/models/network-protocol/index.js
@@ -1,9 +1,8 @@
 const path = require('path')
-const { renameKeys, joinUrl, getUpdates } = require('../../lib/utils')
+const { renameKeys, getUpdates } = require('../../lib/utils')
 const registerNetworkProtocols = require('../../networkProtocols/register')
 const { load, update, remove, loadByQuery } = require('../model-lib')
 const httpError = require('http-errors')
-const R = require('ramda')
 
 // ******************************************************************************
 // Fragments for how the data should be returned from Prisma.
@@ -23,8 +22,6 @@ const fragments = {
   }`
 }
 
-const nameDesc = ['name', 'description']
-
 // ******************************************************************************
 // Helpers
 // ******************************************************************************
@@ -40,6 +37,11 @@ const renameQueryKeys = renameKeys({
   search: 'name_contains',
   networkProtocolVersion: 'networkProtocolVersion_contains'
 })
+
+const handlerCommand = command => async (ctx, args) => {
+  const handler = await ctx.$self.getHandler(args.network.networkProtocol)
+  return handler[command](args)
+}
 
 // ******************************************************************************
 // Model Functions
@@ -97,301 +99,12 @@ async function getHandler (ctx, { id }) {
 // ******************************************************************************
 // Network Protocol Handler API
 // ******************************************************************************
-const handlerCommand = command => async (ctx, args) => {
-  const handler = await ctx.$self.getHandler(args.network.networkProtocol)
-  return handler[command](args)
-}
-
 async function test (ctx, { network }) {
   if (!network.meta.authorized) {
     throw httpError.Unauthorized()
   }
   const handler = await ctx.$self.getHandler(network.networkProtocol)
   await handler.test({ network })
-}
-
-async function pullNetwork (ctx, { network }) {
-  const [apps, deviceProfiles] = await Promise.all([
-    ctx.$self.pullApplications({ network }),
-    ctx.$self.pullDeviceProfiles({ network })
-  ])
-  await Promise.all(apps.map(app => ctx.$self.pullDevices({ network, ...app, deviceProfiles })))
-}
-
-async function pullApplications (ctx, { network }) {
-  const handler = await ctx.$self.getHandler(network.networkProtocol)
-  const remoteApps = await handler.listAllApplications({ network })
-  return Promise.all(remoteApps.map(async remoteApplication => {
-    const appData = await handler.buildApplication({ network, remoteApplication })
-    const origin = { network, remoteId: appData.id }
-    if (appData.baseUrl) {
-      // if appData.baseUrl includes the network ID, the app is already activated
-      // delete baseUrl so that it doesn't overwrite link to application server
-      if (appData.baseUrl.includes(network.id)) {
-        delete appData.baseUrl
-      }
-      else {
-        const postReportingProtocol = await ctx.$m.reportingProtocol.load({ where: { name: 'POST' } })
-        appData.reportingProtocol = { id: postReportingProtocol.id }
-      }
-    }
-    const application = await ctx.$m.application.upsert({
-      data: R.pick([...nameDesc, 'baseUrl', 'reportingProtocol'], appData),
-      origin
-    })
-    const appNtlData = {
-      networkSettings: R.omit([...nameDesc, 'id', 'baseUrl', 'reportingProtocol'], appData),
-      networkType: network.networkType,
-      application: { id: application.id }
-    }
-    if (appData.baseUrl) appNtlData.enabled = true
-    const applicationNetworkTypeLink = await ctx.$m.applicationNetworkTypeLink.upsert({
-      origin,
-      data: appNtlData
-    })
-    return { application, applicationNetworkTypeLink, remoteApplication }
-  }))
-}
-
-async function pullDeviceProfiles (ctx, { network }) {
-  const handler = await ctx.$self.getHandler(network.networkProtocol)
-  const remoteDeviceProfiles = await handler.listAllDeviceProfiles({ network })
-  return Promise.all(remoteDeviceProfiles.map(async remoteDeviceProfile => {
-    const dpData = await handler.buildDeviceProfile({ network, remoteDeviceProfile })
-    const origin = { network, remoteId: dpData.id }
-    const deviceProfile = await ctx.$m.deviceProfile.upsert({
-      origin,
-      data: {
-        ...R.pick(nameDesc, dpData),
-        networkSettings: R.omit([...nameDesc, 'id'], dpData),
-        networkType: network.networkType
-      }
-    })
-    return { deviceProfile, remoteDeviceProfile }
-  }))
-}
-
-async function pullDevices (ctx, { network, application, remoteApplication, deviceProfiles }) {
-  ctx.log.debug('pullDevices', { application })
-  const handler = await ctx.$self.getHandler(network.networkProtocol)
-  const remoteDevices = await handler.listAllApplicationDevices({ network, remoteApplication })
-  return Promise.all(remoteDevices.map(async remoteDevice => {
-    const { deviceProfile } = deviceProfiles.find(x => x.remoteDeviceProfile.id === remoteDevice.deviceProfileID) || {}
-    const devData = await handler.buildDevice({
-      network,
-      remoteDevice,
-      deviceProfile: deviceProfile.networkSettings
-    })
-    const origin = { network, remoteId: devData.id }
-    const device = await ctx.$m.device.upsert({
-      origin,
-      data: { ...R.pick(nameDesc, devData), applicationId: application.id }
-    })
-    let devNtlData = {
-      networkSettings: R.omit([...nameDesc, 'id'], devData),
-      device: { id: device.id },
-      networkType: { id: network.networkType.id }
-    }
-    if (deviceProfile) {
-      devNtlData.deviceProfile = { id: deviceProfile.id }
-    }
-    const deviceNetworkTypeLink = await ctx.$m.deviceNetworkTypeLink.upsert({
-      origin,
-      data: devNtlData
-    })
-    return { device, deviceNetworkTypeLink }
-  }))
-}
-
-async function pushNetwork (ctx, { network }) {
-  ctx.log.debug('networkProtocol:pushNetwork', { network })
-  await Promise.all([
-    ctx.$self.pushApplications({ network }),
-    ctx.$self.pushDeviceProfiles({ network })
-  ])
-  await ctx.$self.pushDevices({ network })
-}
-
-async function pushApplications (ctx, { network }) {
-  const [appNtls] = await ctx.$m.applicationNetworkTypeLink.list({
-    where: { networkType: network.networkType },
-    limit: 9999
-  })
-  const [nwkDeployments] = await ctx.$m.networkDeployment.list({
-    where: { network: { id: network.id }, type: 'APPLICATION' },
-    limit: 9999
-  })
-  const notDeployed = appNtls.filter(x => !nwkDeployments.find(y => y.application.id === x.application.id))
-  return Promise.all(notDeployed.map(appNtl => ctx.$m.networkDeployment.create({
-    data: {
-      status: 'CREATED',
-      type: 'APPLICATION',
-      meta: { enabled: false },
-      network: { id: network.id },
-      application: appNtl.application
-    }
-  })))
-}
-
-async function pushDeviceProfiles (ctx, { network }) {
-  const [deviceProfiles] = await ctx.$m.deviceProfile.list({
-    where: { networkType: network.networkType },
-    limit: 9999
-  })
-  const [nwkDeployments] = await ctx.$m.networkDeployment.list({
-    where: { network: { id: network.id }, type: 'DEVICE_PROFILE' },
-    limit: 9999
-  })
-  const notDeployed = deviceProfiles.filter(x => !nwkDeployments.find(y => y.deviceProfile.id === x.id))
-  return Promise.all(notDeployed.map(devProfile => ctx.$m.networkDeployment.create({
-    data: {
-      status: 'CREATED',
-      type: 'DEVICE_PROFILE',
-      meta: {},
-      network: { id: network.id },
-      deviceProfile: { id: devProfile.id }
-    }
-  })))
-}
-
-async function pushDevices (ctx, { network }) {
-  const [devNtls] = await ctx.$m.deviceNetworkTypeLink.list({
-    where: { networkType: network.networkType },
-    limit: 9999
-  })
-  const [nwkDeployments] = await ctx.$m.networkDeployment.list({
-    where: { network: { id: network.id }, type: 'DEVICE' },
-    limit: 9999
-  })
-  const notDeployed = devNtls.filter(x => !nwkDeployments.find(y => y.device.id === x.device.id))
-  return Promise.all(notDeployed.map(devNtl => ctx.$m.networkDeployment.create({
-    data: {
-      status: 'CREATED',
-      type: 'DEVICE',
-      meta: {},
-      network: { id: network.id },
-      device: devNtl.device
-    }
-  })))
-}
-
-async function syncApplication (ctx, { network, networkDeployment }) {
-  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
-  let meta = { ...networkDeployment.meta }
-  if (networkDeployment.status === 'REMOVED') {
-    if (meta.isOrigin) return
-    return handler.removeApplication({ network, remoteId: meta.remoteId, stopApplication: meta.enabled })
-  }
-  const [application, applicationNetworkTypeLink] = await Promise.all([
-    ctx.$m.application.load({ where: networkDeployment.application }),
-    ctx.$m.applicationNetworkTypeLink.loadByQuery({
-      where: { networkType: network.networkType, application: networkDeployment.application }
-    })
-  ])
-  let args = {
-    network,
-    remoteId: meta.remoteId,
-    application: {
-      ...R.pick(nameDesc, application),
-      ...applicationNetworkTypeLink.networkSettings
-    }
-  }
-  if (networkDeployment.status === 'CREATED' && !meta.isOrigin) {
-    let remoteDoc = await handler.createApplication(args)
-    meta.remoteId = remoteDoc.id
-    networkDeployment = { ...networkDeployment, meta }
-  }
-  else if (networkDeployment.status === 'UPDATED') {
-    await handler.updateApplication(args)
-  }
-  const { enabled } = applicationNetworkTypeLink
-  if (networkDeployment.meta.enabled !== enabled) {
-    if (enabled) {
-      const url = joinUrl(ctx.config.base_url, 'api/uplinks', application.id, network.id)
-      await handler.startApplication({ network, networkDeployment, url })
-    }
-    else {
-      await handler.stopApplication({ network, networkDeployment })
-    }
-    meta.enabled = enabled
-  }
-  return meta
-}
-
-async function syncDeviceProfile (ctx, { network, networkDeployment }) {
-  let meta = { ...networkDeployment.meta }
-  if (networkDeployment.status === 'CREATED' && meta.isOrigin) {
-    return meta
-  }
-  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
-  if (networkDeployment.status === 'REMOVED') {
-    if (meta.isOrigin) return
-    return handler.removeDeviceProfile({ network, remoteId: meta.remoteId })
-  }
-  const deviceProfile = await ctx.$m.deviceProfile.load({ where: networkDeployment.deviceProfile })
-  let args = {
-    network,
-    remoteId: meta.remoteId,
-    deviceProfile: {
-      ...R.pick(nameDesc, deviceProfile),
-      ...deviceProfile.networkSettings
-    }
-  }
-  if (networkDeployment.status === 'CREATED') {
-    let remoteDoc = await handler.createDeviceProfile(args)
-    meta.remoteId = remoteDoc.id
-  }
-  else if (networkDeployment.status === 'UPDATED') {
-    await handler.updateDeviceProfile(args)
-  }
-  return meta
-}
-
-async function syncDevice (ctx, { network, networkDeployment }) {
-  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
-  let meta = { ...networkDeployment.meta }
-  if (networkDeployment.status === 'REMOVED') {
-    if (meta.isOrigin) return
-    return handler.removeDevice({ network, remoteId: meta.remoteId })
-  }
-  const [device, deviceNetworkTypeLink] = await Promise.all([
-    ctx.$m.device.load({ where: networkDeployment.device }),
-    ctx.$m.deviceNetworkTypeLink.loadByQuery({
-      where: { networkType: network.networkType, device: networkDeployment.device }
-    })
-  ])
-  const [appNwkDep, dpNwkDep, deviceProfile] = await Promise.all([
-    ctx.$m.networkDeployment.loadByQuery({
-      where: { network: { id: network.id }, application: device.application }
-    }),
-    ctx.$m.networkDeployment.loadByQuery({
-      where: { network: { id: network.id }, deviceProfile: deviceNetworkTypeLink.deviceProfile }
-    }),
-    ctx.$m.deviceProfile.load({ where: deviceNetworkTypeLink.deviceProfile })
-  ])
-  let args = {
-    network,
-    remoteId: meta.remoteId,
-    remoteApplicationId: appNwkDep.meta.remoteId,
-    remoteDeviceProfileId: dpNwkDep.meta.remoteId,
-    deviceProfile: {
-      ...R.pick(nameDesc, deviceProfile),
-      ...deviceProfile.networkSettings
-    },
-    device: {
-      ...R.pick(nameDesc, device),
-      ...deviceNetworkTypeLink.networkSettings
-    }
-  }
-  if (networkDeployment.status === 'CREATED' && !meta.isOrigin) {
-    ctx.log.debug('syncDevice', R.pick(['device', 'deviceProfile'], args))
-    let remoteDoc = await handler.createDevice(args)
-    meta.remoteId = remoteDoc.id
-  }
-  else if (networkDeployment.status === 'UPDATED') {
-    await handler.updateDevice(args)
-  }
-  return meta
 }
 
 async function relayUplink (ctx, args) {
@@ -437,19 +150,11 @@ module.exports = {
     connect: handlerCommand('connect'),
     disconnect: handlerCommand('disconnect'),
     test,
-    pushNetwork,
-    pullNetwork,
-    pullApplications,
-    pushApplications,
-    pullDeviceProfiles,
-    pushDeviceProfiles,
-    pullDevices,
-    pushDevices,
     relayUplink,
-    syncApplication,
-    syncDeviceProfile,
-    syncDevice,
-    passDataToDevice
+    passDataToDevice,
+    ...require('./network-pull'),
+    ...require('./network-push'),
+    ...require('./network-deployment-sync')
   },
   fragments
 }

--- a/app/models/network-protocol/network-deployment-sync.js
+++ b/app/models/network-protocol/network-deployment-sync.js
@@ -1,0 +1,130 @@
+const R = require('ramda')
+const { joinUrl } = require('../../lib/utils')
+
+const nameDesc = ['name', 'description']
+
+async function syncApplication (ctx, { network, networkDeployment }) {
+  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
+  let meta = { ...networkDeployment.meta }
+  if (networkDeployment.status === 'REMOVED') {
+    if (meta.isOrigin) return
+    return handler.removeApplication({ network, remoteId: meta.remoteId, stopApplication: meta.enabled })
+  }
+  const [application, applicationNetworkTypeLink] = await Promise.all([
+    ctx.$m.application.load({ where: networkDeployment.application }),
+    ctx.$m.applicationNetworkTypeLink.loadByQuery({
+      where: { networkType: network.networkType, application: networkDeployment.application }
+    })
+  ])
+  let args = {
+    network,
+    remoteId: meta.remoteId,
+    application: {
+      ...R.pick(nameDesc, application),
+      ...applicationNetworkTypeLink.networkSettings
+    }
+  }
+  if (networkDeployment.status === 'CREATED' && !meta.isOrigin) {
+    let remoteDoc = await handler.createApplication(args)
+    meta.remoteId = remoteDoc.id
+    networkDeployment = { ...networkDeployment, meta }
+  }
+  else if (networkDeployment.status === 'UPDATED') {
+    await handler.updateApplication(args)
+  }
+  const { enabled } = applicationNetworkTypeLink
+  if (networkDeployment.meta.enabled !== enabled) {
+    if (enabled) {
+      const url = joinUrl(ctx.config.base_url, 'api/uplinks', application.id, network.id)
+      await handler.startApplication({ network, networkDeployment, url })
+    }
+    else {
+      await handler.stopApplication({ network, networkDeployment })
+    }
+    meta.enabled = enabled
+  }
+  return meta
+}
+
+async function syncDeviceProfile (ctx, { network, networkDeployment }) {
+  let meta = { ...networkDeployment.meta }
+  if (networkDeployment.status === 'CREATED' && meta.isOrigin) {
+    return meta
+  }
+  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
+  if (networkDeployment.status === 'REMOVED') {
+    if (meta.isOrigin) return
+    return handler.removeDeviceProfile({ network, remoteId: meta.remoteId })
+  }
+  const deviceProfile = await ctx.$m.deviceProfile.load({ where: networkDeployment.deviceProfile })
+  let args = {
+    network,
+    remoteId: meta.remoteId,
+    deviceProfile: {
+      ...R.pick(nameDesc, deviceProfile),
+      ...deviceProfile.networkSettings
+    }
+  }
+  if (networkDeployment.status === 'CREATED') {
+    let remoteDoc = await handler.createDeviceProfile(args)
+    meta.remoteId = remoteDoc.id
+  }
+  else if (networkDeployment.status === 'UPDATED') {
+    await handler.updateDeviceProfile(args)
+  }
+  return meta
+}
+
+async function syncDevice (ctx, { network, networkDeployment }) {
+  const handler = await ctx.$self.getHandler({ id: network.networkProtocol.id })
+  let meta = { ...networkDeployment.meta }
+  if (networkDeployment.status === 'REMOVED') {
+    if (meta.isOrigin) return
+    return handler.removeDevice({ network, remoteId: meta.remoteId })
+  }
+  const [device, deviceNetworkTypeLink] = await Promise.all([
+    ctx.$m.device.load({ where: networkDeployment.device }),
+    ctx.$m.deviceNetworkTypeLink.loadByQuery({
+      where: { networkType: network.networkType, device: networkDeployment.device }
+    })
+  ])
+  const [appNwkDep, dpNwkDep, deviceProfile] = await Promise.all([
+    ctx.$m.networkDeployment.loadByQuery({
+      where: { network: { id: network.id }, application: device.application }
+    }),
+    ctx.$m.networkDeployment.loadByQuery({
+      where: { network: { id: network.id }, deviceProfile: deviceNetworkTypeLink.deviceProfile }
+    }),
+    ctx.$m.deviceProfile.load({ where: deviceNetworkTypeLink.deviceProfile })
+  ])
+  let args = {
+    network,
+    remoteId: meta.remoteId,
+    remoteApplicationId: appNwkDep.meta.remoteId,
+    remoteDeviceProfileId: dpNwkDep.meta.remoteId,
+    deviceProfile: {
+      ...R.pick(nameDesc, deviceProfile),
+      ...deviceProfile.networkSettings
+    },
+    device: {
+      ...R.pick(nameDesc, device),
+      ...deviceNetworkTypeLink.networkSettings
+    }
+  }
+  if (networkDeployment.status === 'CREATED' && !meta.isOrigin) {
+    ctx.log.debug('syncDevice', R.pick(['device', 'deviceProfile'], args))
+    let remoteDoc = await handler.createDevice(args)
+    meta.remoteId = remoteDoc.id
+  }
+  else if (networkDeployment.status === 'UPDATED') {
+    await handler.updateDevice(args)
+  }
+  return meta
+}
+
+
+module.exports = {
+  syncApplication,
+  syncDeviceProfile,
+  syncDevice
+}

--- a/app/models/network-protocol/network-pull.js
+++ b/app/models/network-protocol/network-pull.js
@@ -1,0 +1,103 @@
+const R = require('ramda')
+
+const nameDesc = ['name', 'description']
+
+async function pullNetwork (ctx, { network }) {
+  const [apps, deviceProfiles] = await Promise.all([
+    ctx.$self.pullApplications({ network }),
+    ctx.$self.pullDeviceProfiles({ network })
+  ])
+  await Promise.all(apps.map(app => ctx.$self.pullApplicationDevices({ network, ...app, deviceProfiles })))
+}
+
+async function pullApplications (ctx, { network }) {
+  const handler = await ctx.$self.getHandler(network.networkProtocol)
+  const remoteApps = await handler.listAllApplications({ network })
+  return Promise.all(remoteApps.map(async remoteApplication => {
+    const appData = await handler.buildApplication({ network, remoteApplication })
+    const origin = { network, remoteId: appData.id }
+    if (appData.baseUrl) {
+      // if appData.baseUrl includes the network ID, the app is already activated
+      // delete baseUrl so that it doesn't overwrite link to application server
+      if (appData.baseUrl.includes(network.id)) {
+        delete appData.baseUrl
+      }
+      else {
+        const postReportingProtocol = await ctx.$m.reportingProtocol.load({ where: { name: 'POST' } })
+        appData.reportingProtocol = { id: postReportingProtocol.id }
+      }
+    }
+    const application = await ctx.$m.application.upsert({
+      data: R.pick([...nameDesc, 'baseUrl', 'reportingProtocol'], appData),
+      origin
+    })
+    const appNtlData = {
+      networkSettings: R.omit([...nameDesc, 'id', 'baseUrl', 'reportingProtocol'], appData),
+      networkType: network.networkType,
+      application: { id: application.id }
+    }
+    if (appData.baseUrl) appNtlData.enabled = true
+    const applicationNetworkTypeLink = await ctx.$m.applicationNetworkTypeLink.upsert({
+      origin,
+      data: appNtlData
+    })
+    return { application, applicationNetworkTypeLink, remoteApplication }
+  }))
+}
+
+async function pullDeviceProfiles (ctx, { network }) {
+  const handler = await ctx.$self.getHandler(network.networkProtocol)
+  const remoteDeviceProfiles = await handler.listAllDeviceProfiles({ network })
+  return Promise.all(remoteDeviceProfiles.map(async remoteDeviceProfile => {
+    const dpData = await handler.buildDeviceProfile({ network, remoteDeviceProfile })
+    const origin = { network, remoteId: dpData.id }
+    const deviceProfile = await ctx.$m.deviceProfile.upsert({
+      origin,
+      data: {
+        ...R.pick(nameDesc, dpData),
+        networkSettings: R.omit([...nameDesc, 'id'], dpData),
+        networkType: network.networkType
+      }
+    })
+    return { deviceProfile, remoteDeviceProfile }
+  }))
+}
+
+async function pullApplicationDevices (ctx, { network, application, remoteApplication, deviceProfiles }) {
+  ctx.log.debug('pullApplicationDevices', { application })
+  const handler = await ctx.$self.getHandler(network.networkProtocol)
+  const remoteDevices = await handler.listAllApplicationDevices({ network, remoteApplication })
+  return Promise.all(remoteDevices.map(async remoteDevice => {
+    const { deviceProfile } = deviceProfiles.find(x => x.remoteDeviceProfile.id === remoteDevice.deviceProfileID) || {}
+    const devData = await handler.buildDevice({
+      network,
+      remoteDevice,
+      deviceProfile: deviceProfile.networkSettings
+    })
+    const origin = { network, remoteId: devData.id }
+    const device = await ctx.$m.device.upsert({
+      origin,
+      data: { ...R.pick(nameDesc, devData), applicationId: application.id }
+    })
+    let devNtlData = {
+      networkSettings: R.omit([...nameDesc, 'id'], devData),
+      device: { id: device.id },
+      networkType: { id: network.networkType.id }
+    }
+    if (deviceProfile) {
+      devNtlData.deviceProfile = { id: deviceProfile.id }
+    }
+    const deviceNetworkTypeLink = await ctx.$m.deviceNetworkTypeLink.upsert({
+      origin,
+      data: devNtlData
+    })
+    return { device, deviceNetworkTypeLink }
+  }))
+}
+
+module.exports = {
+  pullNetwork,
+  pullApplications,
+  pullDeviceProfiles,
+  pullApplicationDevices
+}

--- a/app/models/network-protocol/network-push.js
+++ b/app/models/network-protocol/network-push.js
@@ -1,0 +1,141 @@
+async function pushNetwork (ctx, { network }) {
+  await Promise.all([
+    ctx.$self.pushApplications({ network, pushDevices: true }),
+    ctx.$self.pushDeviceProfiles({ network })
+  ])
+}
+
+async function pushApplications (ctx, { network, pushDevices }) {
+  const where = { networkType: network.networkType }
+  for await (let state of ctx.$m.applicationNetworkTypeLink.listAll({ where })) {
+    await Promise.all(state.records.map(x => ctx.$self.pushApplication({
+      network,
+      applicationId: x.application.id,
+      pushDevices
+    })))
+  }
+}
+
+async function pushApplication (ctx, { network, applicationId, pushDevices = false }) {
+  const application = { id: applicationId }
+  try {
+    const nwkDeployment = await ctx.$m.networkDeployment.loadByQuery({
+      application,
+      network: { id: network.id }
+    })
+    if (nwkDeployment.status !== 'SYNCED') {
+      await ctx.$m.networkDeployment.update({ where: { id: nwkDeployment.id }, data: { status: 'UPDATED' } })
+    }
+  }
+  catch (err) {
+    if (err.statusCode !== 404) throw err
+    await ctx.$m.networkDeployment.create({
+      data: {
+        status: 'CREATED',
+        type: 'APPLICATION',
+        meta: { enabled: false },
+        network: { id: network.id },
+        application
+      }
+    })
+  }
+  if (!pushDevices) return
+  await ctx.$self.pushApplicationDevices({ network, applicationId })
+}
+
+async function pushDeviceProfiles (ctx, { network, pushDevices }) {
+  const where = { networkType: network.networkType }
+  for await (let state of ctx.$m.deviceProfile.listAll({ where })) {
+    await Promise.all(state.records.map(x => ctx.$self.pushDeviceProfile({
+      network,
+      deviceProfileId: x.id,
+      pushDevices
+    })))
+  }
+}
+
+async function pushDeviceProfile (ctx, { network, deviceProfileId, pushDevices = false }) {
+  const deviceProfile = { id: deviceProfileId }
+  try {
+    const nwkDeployment = await ctx.$m.networkDeployment.loadByQuery({
+      deviceProfile,
+      network: { id: network.id }
+    })
+    if (nwkDeployment.status !== 'SYNCED') {
+      await ctx.$m.networkDeployment.update({ where: { id: nwkDeployment.id }, data: { status: 'UPDATED' } })
+    }
+  }
+  catch (err) {
+    if (err.statusCode !== 404) throw err
+    await ctx.$m.networkDeployment.create({
+      data: {
+        status: 'CREATED',
+        type: 'DEVICE_PROFILE',
+        meta: {},
+        network: { id: network.id },
+        deviceProfile
+      }
+    })
+  }
+  if (!pushDevices) return
+  await ctx.$self.pushDeviceProfileDevices({ network, deviceProfileId })
+}
+
+async function pushApplicationDevices (ctx, { network, applicationId }) {
+  const where = { application: { id: applicationId } }
+  for await (let state of ctx.$m.device.listAll({ where })) {
+    await Promise.all(state.records.map(x => ctx.$self.pushDevice({
+      network,
+      deviceId: x.id
+    })))
+  }
+}
+
+async function pushDeviceProfileDevices (ctx, { network, deviceProfileId }) {
+  const where = {
+    deviceProfile: { id: deviceProfileId },
+    networkType: network.networkType
+  }
+  for await (let state of ctx.$m.deviceNetworkTypeLinks.listAll({ where })) {
+    await Promise.all(state.records.map(x => ctx.$self.pushDevice({
+      network,
+      deviceId: x.device.id
+    })))
+  }
+}
+
+async function pushDevice (ctx, { network, deviceId }) {
+  const device = { id: deviceId }
+  try {
+    const nwkDeployment = await ctx.$m.networkDeployment.loadByQuery({
+      device,
+      network: { id: network.id }
+    })
+    if (nwkDeployment.status !== 'SYNCED') {
+      await ctx.$m.networkDeployment.update({ where: { id: nwkDeployment.id }, data: { status: 'UPDATED' } })
+    }
+  }
+  catch (err) {
+    if (err.statusCode !== 404) throw err
+    await ctx.$m.networkDeployment.create({
+      data: {
+        status: 'CREATED',
+        type: 'DEVICE',
+        meta: {},
+        network: { id: network.id },
+        device
+      }
+    })
+  }
+}
+
+module.exports = {
+  pushNetwork,
+  pushApplications,
+  pushApplication,
+  pushApplicationDevices,
+  pushDeviceProfiles,
+  pushDeviceProfile,
+  pushDeviceProfileDevices,
+  pushDevice
+}

--- a/app/models/user/permissions.js
+++ b/app/models/user/permissions.js
@@ -7,8 +7,8 @@ const resources = [
   'DeviceNetworkTypeLink',
   'DeviceProfile',
   'Network',
+  'NetworkDeployment',
   'NetworkProtocol',
-  'NetworkProvider',
   'NetworkType',
   'ReportingProtocol',
   'User'
@@ -17,7 +17,8 @@ const resources = [
 const otherPermissions = [
   'Session:remove',
   'ApplicationNetworkTypeLink:push',
-  'DeviceNetworkTypeLink:push'
+  'DeviceNetworkTypeLink:push',
+  'DeviceProfile:push'
 ]
 
 function createResourcePermissions (resource, operations) {

--- a/app/rest-server/handlers/index.js
+++ b/app/rest-server/handlers/index.js
@@ -36,7 +36,16 @@ const handlers = {
   ...require('./resources/application').handlers,
 
   // Device custom endpoints
-  ...require('./resources/device').handlers
+  ...require('./resources/device').handlers,
+
+  // ApplicationNetworkTypeLink custom endpoints
+  ...require('./resources/application-network-type-link').handlers,
+
+  // DeviceNetworkTypeLink custom endpoints
+  ...require('./resources/device-network-type-link').handlers,
+
+  // DeviceProfile custom endpoints
+  ...require('./resources/device-profile').handlers
 }
 
 module.exports = handlers

--- a/app/rest-server/handlers/resources/application-network-type-link.js
+++ b/app/rest-server/handlers/resources/application-network-type-link.js
@@ -1,0 +1,21 @@
+const { applicationNetworkTypeLink } = require('../../../models')
+const { pipe, authorize: auth } = require('../openapi-middleware')
+const { requestContext } = require('../crud')
+
+const pushApplicationNetworkTypeLink = appNtlModel => async (ctx, req, res) => {
+  await appNtlModel.push({
+    id: ctx.request.params.id,
+    pushDevices: !!ctx.request.query.pushDevices
+  }, requestContext(req))
+  res.status(204).send()
+}
+
+module.exports = {
+  pushApplicationNetworkTypeLink,
+  handlers: {
+    pushApplicationNetworkTypeLink: pipe(
+      auth(['ApplicationNetworkTypeLink:push']),
+      pushApplicationNetworkTypeLink(applicationNetworkTypeLink)
+    )
+  }
+}

--- a/app/rest-server/handlers/resources/device-network-type-link.js
+++ b/app/rest-server/handlers/resources/device-network-type-link.js
@@ -1,0 +1,20 @@
+const { deviceNetworkTypeLink } = require('../../../models')
+const { pipe, authorize: auth } = require('../openapi-middleware')
+const { requestContext } = require('../crud')
+
+const pushDeviceNetworkTypeLink = devNtlModel => async (ctx, req, res) => {
+  await devNtlModel.push({
+    id: ctx.request.params.id
+  }, requestContext(req))
+  res.status(204).send()
+}
+
+module.exports = {
+  pushDeviceNetworkTypeLink,
+  handlers: {
+    pushDeviceNetworkTypeLink: pipe(
+      auth(['DeviceNetworkTypeLink:push']),
+      pushDeviceNetworkTypeLink(deviceNetworkTypeLink)
+    )
+  }
+}

--- a/app/rest-server/handlers/resources/device-profile.js
+++ b/app/rest-server/handlers/resources/device-profile.js
@@ -1,0 +1,21 @@
+const { deviceProfile } = require('../../../models')
+const { pipe, authorize: auth } = require('../openapi-middleware')
+const { requestContext } = require('../crud')
+
+const pushDeviceProfile = dpModel => async (ctx, req, res) => {
+  await dpModel.push({
+    id: ctx.request.params.id,
+    pushDevices: !!ctx.request.query.pushDevices
+  }, requestContext(req))
+  res.status(204).send()
+}
+
+module.exports = {
+  pushDeviceProfile,
+  handlers: {
+    pushDeviceProfile: pipe(
+      auth(['DeviceProfile:push']),
+      pushDeviceProfile(deviceProfile)
+    )
+  }
+}

--- a/docs/openapi/api.yml
+++ b/docs/openapi/api.yml
@@ -49,6 +49,8 @@ paths:
     $ref: 'endpoints/application-network-type-link.yml#/paths/~1api~1application-network-type-links'
   /api/application-network-type-links/{id}:
     $ref: 'endpoints/application-network-type-link.yml#/paths/~1api~1application-network-type-links~1{id}'
+  /api/application-network-type-links/{id}/push:
+    $ref: 'endpoints/application-network-type-link.yml#/paths/~1api~1application-network-type-links~1{id}~1push'
   /api/devices:
     $ref: 'endpoints/device.yml#/paths/~1api~1devices'
   /api/devices/{id}:
@@ -65,10 +67,14 @@ paths:
     $ref: 'endpoints/device-network-type-link.yml#/paths/~1api~1device-network-type-links'
   /api/device-network-type-links/{id}:
     $ref: 'endpoints/device-network-type-link.yml#/paths/~1api~1device-network-type-links~1{id}'
+  /api/device-network-type-links/{id}/push:
+    $ref: 'endpoints/device-network-type-link.yml#/paths/~1api~1device-network-type-links~1{id}~1push'
   /api/device-profiles:
     $ref: 'endpoints/device-profile.yml#/paths/~1api~1device-profiles'
   /api/device-profiles/{id}:
     $ref: 'endpoints/device-profile.yml#/paths/~1api~1device-profiles~1{id}'
+  /api/device-profiles/{id}/push:
+    $ref: 'endpoints/device-profile.yml#/paths/~1api~1device-profiles~1{id}~1push'
   /api/networks:
     $ref: 'endpoints/network.yml#/paths/~1api~1networks'
   /api/networks/{id}:
@@ -151,6 +157,16 @@ components:
       required: false
       schema:
         type: string
+    pushDevices:
+      name: pushDevices
+      in: query
+      description: Whether to also push devices when pushing an ApplicationNetworkTypeLink or a DeviceProfile
+      required: false
+      schema:
+        type: string
+        enum:
+        - 'true'
+        - 'false'
   schemas:
     ResourceCreatedResponse:
       type: object

--- a/docs/openapi/dist/api.yml
+++ b/docs/openapi/dist/api.yml
@@ -476,6 +476,33 @@ paths:
           description: ApplicationNetworkTypeLink record was deleted
         "404":
           description: ApplicationNetworkTypeLink not found
+  "/api/application-network-type-links/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushApplicationNetworkTypeLink
+      summary: Push ApplicationNetworkTypeLink
+      description: Push Application to all Networks of this NetworkType
+      parameters:
+        - name: pushDevices
+          in: query
+          description: Whether to also push devices when pushing an
+            ApplicationNetworkTypeLink or a DeviceProfile
+          required: false
+          schema:
+            type: string
+            enum:
+              - "true"
+              - "false"
+      security:
+        - bearer_token: []
+      tags:
+        - ApplicationNetworkTypeLink
+      responses:
+        "204":
+          description: ApplicationNetworkTypeLink was pushed
+        "404":
+          description: ApplicationNetworkTypeLink not found
   /api/devices:
     post:
       operationId: createDevice
@@ -834,6 +861,7 @@ paths:
                   required:
                     - deviceId
                     - networkTypeId
+                    - deviceProfileId
         description: DeviceNetworkTypeLink to be created
         required: true
       responses:
@@ -975,6 +1003,22 @@ paths:
       responses:
         "204":
           description: DeviceNetworkTypeLink record was deleted
+        "404":
+          description: DeviceNetworkTypeLink not found
+  "/api/device-network-type-links/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushDeviceNetworkTypeLink
+      summary: Push DeviceNetworkTypeLink
+      description: Push Device to all Networks of this NetworkType
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceNetworkTypeLink
+      responses:
+        "204":
+          description: DeviceNetworkTypeLink was pushed
         "404":
           description: DeviceNetworkTypeLink not found
   /api/device-profiles:
@@ -1140,6 +1184,25 @@ paths:
       responses:
         "204":
           description: DeviceProfile record was deleted
+        "404":
+          description: DeviceProfile not found
+  "/api/device-profiles/{id}/push":
+    parameters:
+      - $ref: "#/paths/~1api~1applications~1%7Bid%7D/parameters/0"
+    post:
+      operationId: pushDeviceProfile
+      summary: Push DeviceProfile
+      description: Push DeviceProfile to all Networks of this NetworkType
+      parameters:
+        - $ref: "#/paths/~1api~1application-network-type-links~1%7Bid%7D~1push/post\
+            /parameters/0"
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceProfile
+      responses:
+        "204":
+          description: DeviceProfile was pushed
         "404":
           description: DeviceProfile not found
   /api/networks:
@@ -1891,6 +1954,17 @@ components:
       required: false
       schema:
         type: string
+    pushDevices:
+      name: pushDevices
+      in: query
+      description: Whether to also push devices when pushing an ApplicationNetworkTypeLink
+        or a DeviceProfile
+      required: false
+      schema:
+        type: string
+        enum:
+          - "true"
+          - "false"
   schemas:
     ResourceCreatedResponse:
       type: object

--- a/docs/openapi/endpoints/application-network-type-link.yml
+++ b/docs/openapi/endpoints/application-network-type-link.yml
@@ -101,6 +101,24 @@ paths:
           description: ApplicationNetworkTypeLink record was deleted
         '404':
           description: ApplicationNetworkTypeLink not found
+  /api/application-network-type-links/{id}/push:
+    parameters:
+      - $ref: '../api.yml#/components/parameters/idParam'
+    post:
+      operationId: pushApplicationNetworkTypeLink
+      summary: Push ApplicationNetworkTypeLink
+      description: Push Application to all Networks of this NetworkType
+      parameters:
+        - $ref: '../api.yml#/components/parameters/pushDevices'
+      security:
+        - bearer_token: []
+      tags:
+        - ApplicationNetworkTypeLink
+      responses:
+        '204':
+          description: ApplicationNetworkTypeLink was pushed
+        '404':
+          description: ApplicationNetworkTypeLink not found
 components:
   schemas:
     ApplicationNetworkTypeLink:

--- a/docs/openapi/endpoints/device-network-type-link.yml
+++ b/docs/openapi/endpoints/device-network-type-link.yml
@@ -102,6 +102,22 @@ paths:
           description: DeviceNetworkTypeLink record was deleted
         '404':
           description: DeviceNetworkTypeLink not found
+  /api/device-network-type-links/{id}/push:
+    parameters:
+      - $ref: '../api.yml#/components/parameters/idParam'
+    post:
+      operationId: pushDeviceNetworkTypeLink
+      summary: Push DeviceNetworkTypeLink
+      description: Push Device to all Networks of this NetworkType
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceNetworkTypeLink
+      responses:
+        '204':
+          description: DeviceNetworkTypeLink was pushed
+        '404':
+          description: DeviceNetworkTypeLink not found
 components:
   schemas:
     DeviceNetworkTypeLink:

--- a/docs/openapi/endpoints/device-profile.yml
+++ b/docs/openapi/endpoints/device-profile.yml
@@ -101,6 +101,24 @@ paths:
           description: DeviceProfile record was deleted
         '404':
           description: DeviceProfile not found
+  /api/device-profiles/{id}/push:
+    parameters:
+      - $ref: '../api.yml#/components/parameters/idParam'
+    post:
+      operationId: pushDeviceProfile
+      summary: Push DeviceProfile
+      description: Push DeviceProfile to all Networks of this NetworkType
+      parameters:
+        - $ref: '../api.yml#/components/parameters/pushDevices'
+      security:
+        - bearer_token: []
+      tags:
+        - DeviceProfile
+      responses:
+        '204':
+          description: DeviceProfile was pushed
+        '404':
+          description: DeviceProfile not found
 components:
   schemas:
     DeviceProfile:

--- a/test/e2e-https/tests/transfer-lora-network/test.spec.js
+++ b/test/e2e-https/tests/transfer-lora-network/test.spec.js
@@ -127,7 +127,8 @@ describe('Transfer Lora Server v1 network to Lora Server v2', () => {
         }
         else {
           const remoteDevKeys = Lora1.cache.DeviceKey.find(x => x.devEUI === lora1Dev.devEUI)
-          assert.strictEqual(remoteDevKeys.appKey, ns.deviceKeys.nwkKey)
+          console.log(JSON.stringify(remoteDevKeys))
+          assert.strictEqual(remoteDevKeys.appKey, ns.deviceKeys.appKey)
         }
       })
       return Promise.all(promises)


### PR DESCRIPTION
#### What does this PR do?
- Solidify the API for push/pull in the initial release of v2. (#349)
- Enhance NetworkProtocol model API around push, all scoped to one Network
- Use that API in ApplicationNetworkTypeLink, DeviceNetworkTypeLink, and DeviceProfile to expose the same functionality for one entity across all Networks of a NetworkType.
- Expose the AppNTL, DeviceNTL, and DeviceProfile model methods in the REST API.

#### Do you have any concerns with this PR?
Testing.  The AppNTL and DeviceNTL REST API tests have been disabled since before I worked on LPWAN.  To fix them is a separate issue, and a prerequisite of adding tests for the new API endpoints.  I made an issue for enabling and fixing the tests, and adding tests for the push endpoints (#358).  Most of the push/pull logic is tested implicitly in the e2e tests when pulling/pushing Networks. 

#### How can the reviewer verify this PR?
View

#### Any background context you want to provide?

#### Screenshots or logs (if appropriate)

#### Questions:
- Have you connected this PR to the issue it resolves? #349 
- Does the documentation need an update? OpenAPI docs updated
- Does this add new dependencies? No
- Have you added unit or functional tests for this PR? No
